### PR TITLE
Add autoprefixer to the Showroom 🎪

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react": "^15.0.2"
   },
   "devDependencies": {
+    "autoprefixer": "^6.4.1",
     "autoprefixer-loader": "^3.1.0",
     "babel-core": "^6.7.4",
     "babel-eslint": "^6.1.2",
@@ -56,6 +57,7 @@
     "null-loader": "^0.1.1",
     "phantomjs": "^1.9.19",
     "phantomjs-polyfill": "0.0.2",
+    "postcss-loader": "^0.13.0",
     "ramda": "^0.21.0",
     "react": "^15.0.2",
     "react-addons-test-utils": "^15.0.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 var path = require('path')
+var autoprefixer = require('autoprefixer')
 var Webpack = require('webpack')
 var WebpackHtmlWebpackPlugin = require('html-webpack-plugin')
 var WebpackErrorNotificationPlugin = require('webpack-error-notification')
@@ -28,6 +29,7 @@ module.exports = {
         loaders: [
           'style',
           'css?modules,localIdentName=[local]',
+          'postcss',
           'sass'
         ]
       },
@@ -63,5 +65,6 @@ module.exports = {
     root: path.join(__dirname),
     exclude: /node_modules/,
     extensions: ['', '.js', '.jsx', '.es6']
-  }
+  },
+  postcss: () => [autoprefixer]
 }


### PR DESCRIPTION
This is to make the Dropdowns behave as they should, which are in the final products but not in the Showroom (whole area clickable).