### PR TITLE
(WIP) Make auto controlled

### DIFF
--- a/Field/example.jsx
+++ b/Field/example.jsx
@@ -9,7 +9,7 @@ const Single = {
 import UncontrolledField from '@klarna/ui/uncontrolled/Field'`,
 
   Regular: (
-    <Field label='Enter your email' />
+    <Field label='Enter your email' defaultValue='asdf' />
   ),
 
   Uncontrolled: (

--- a/Field/example.jsx
+++ b/Field/example.jsx
@@ -9,7 +9,7 @@ const Single = {
 import UncontrolledField from '@klarna/ui/uncontrolled/Field'`,
 
   Regular: (
-    <Field label='Enter your email' defaultValue='asdf' />
+    <Field label='Enter your email' defaultValue='asdf' focus={false} />
   ),
 
   Uncontrolled: (
@@ -17,11 +17,11 @@ import UncontrolledField from '@klarna/ui/uncontrolled/Field'`,
   ),
 
   'With value': (
-    <Field label='Enter your email' value='jane@doe.com' />
+    <Field autoFocus label='Enter your email' value='jane@doe.com' />
   ),
 
   Big: (
-    <Field label='Enter your email' big />
+    <Field label='Enter your email' value='' big />
   ),
 
   'With focus': (
@@ -37,7 +37,12 @@ import UncontrolledField from '@klarna/ui/uncontrolled/Field'`,
   ),
 
   'Exclude Mouseflow': (
-    <Field mouseflowExclude label='Address' value='16, Corn street' />
+    <Field
+      mouseflowExclude
+      focus={false}
+      label='Address'
+      value='16, Corn street'
+    />
   ),
 
   'With error': (
@@ -153,5 +158,9 @@ import Fieldset from '@klarna/ui/Fieldset'`,
 export default {
   title: 'Field',
   icon: 'Field',
-  variations: [Single, WithIcons, Stacked]
+  variations: [
+    Single,
+    WithIcons,
+    Stacked
+  ]
 }

--- a/Field/index.jsx
+++ b/Field/index.jsx
@@ -7,6 +7,7 @@ import * as inlinedIcon from '../lib/features/inlinedIcon'
 import * as stacking from '../lib/features/stacking'
 import { handleKeyDown } from '../lib/features/keyboardEvents'
 import MouseflowExclude from '../MouseflowExclude'
+import uncontrolled from '../decorators/uncontrolled'
 
 const baseClass = 'field'
 
@@ -21,7 +22,7 @@ const classes = {
   label: `${baseClass}__label`
 }
 
-export default React.createClass({
+export default uncontrolled(React.createClass({
   displayName: 'Field',
 
   getDefaultProps () {
@@ -209,4 +210,8 @@ export default React.createClass({
       </div>
     )
   }
+}), {
+  defaultProp: 'defaultValue',
+  prop: 'value',
+  handler: 'onChange'
 })

--- a/Field/index.jsx
+++ b/Field/index.jsx
@@ -22,7 +22,7 @@ const classes = {
   label: `${baseClass}__label`
 }
 
-export default uncontrolled(React.createClass({
+export default uncontrolled(uncontrolled(React.createClass({
   displayName: 'Field',
 
   getDefaultProps () {
@@ -214,4 +214,9 @@ export default uncontrolled(React.createClass({
   defaultProp: 'defaultValue',
   prop: 'value',
   handler: 'onChange'
+}), {
+  defaultProp: 'autoFocus',
+  prop: 'focus',
+  handler: 'onFocus',
+  reset: 'onBlur'
 })

--- a/decorators/uncontrolled.jsx
+++ b/decorators/uncontrolled.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 
-export default function uncontrolled (Component, {defaultProp, prop, handler}) {
+export default function uncontrolled (Component, {defaultProp, prop, handler, reset}) {
   return class Uncontrolled extends Component {
     componentDidMount () {
       this.setState({
@@ -11,7 +11,7 @@ export default function uncontrolled (Component, {defaultProp, prop, handler}) {
     }
 
     handleHandler (handler, e) {
-      if (this.props[prop]) {
+      if (this.props[prop] != null) {
         handler && handler(e)
       } else {
         this.setState({
@@ -19,12 +19,26 @@ export default function uncontrolled (Component, {defaultProp, prop, handler}) {
             ? e.target.value
             : e
         })
-        handler
+
+        handler && handler(e)
+      }
+    }
+
+    handleReset (handler, e) {
+      if (this.props[prop] != null) {
+        handler && handler(e)
+      } else {
+        this.setState({
+          [prop]: undefined
+        })
+
+        handler && handler(e)
       }
     }
 
     render () {
       const consumerHandler = this.props[handler]
+      const consumerReset = this.props[reset]
 
       const props = Object.keys(this.props)
         .filter(k => k !== handler)
@@ -33,14 +47,15 @@ export default function uncontrolled (Component, {defaultProp, prop, handler}) {
           [k]: this.props[k]
         }), {})
 
-      const handlerProp = {
-        [handler]: this.handleHandler.bind(this, consumerHandler)
+      const handlerProps = {
+        [handler]: this.handleHandler.bind(this, consumerHandler),
+        [reset]: this.handleReset.bind(this, consumerReset)
       }
 
       return <Component
         {...props}
         {...this.state}
-        {...handlerProp}
+        {...handlerProps}
       />
     }
   }

--- a/decorators/uncontrolled.jsx
+++ b/decorators/uncontrolled.jsx
@@ -1,0 +1,47 @@
+import React, { Component } from 'react'
+
+export default function uncontrolled (Component, {defaultProp, prop, handler}) {
+  return class Uncontrolled extends Component {
+    componentDidMount () {
+      this.setState({
+        [prop]: this.props[prop] != null
+          ? this.props[prop] || ''
+          : this.props[defaultProp]
+      })
+    }
+
+    handleHandler (handler, e) {
+      if (this.props[prop]) {
+        handler && handler(e)
+      } else {
+        this.setState({
+          [prop]: e && e.target
+            ? e.target.value
+            : e
+        })
+        handler
+      }
+    }
+
+    render () {
+      const consumerHandler = this.props[handler]
+
+      const props = Object.keys(this.props)
+        .filter(k => k !== handler)
+        .reduce((x, k) => ({
+          ...x,
+          [k]: this.props[k]
+        }), {})
+
+      const handlerProp = {
+        [handler]: this.handleHandler.bind(this, consumerHandler)
+      }
+
+      return <Component
+        {...props}
+        {...this.state}
+        {...handlerProp}
+      />
+    }
+  }
+}


### PR DESCRIPTION
This is a PoC of implementing https://github.com/klarna/ui/issues/45

Apparently the Controlled vs Uncontrolled as entry point level APIs are creating a lot of issues for newcomers to the library. It could make sense to provide Uncontrolled by default and switch to Controlled if a specific prop is passed, such as React does with `<input>`.