### PR TITLE
Add HOC to make anything Uncontrolled on demand

### DIFF
--- a/decorators/uncontrolled.jsx
+++ b/decorators/uncontrolled.jsx
@@ -1,0 +1,62 @@
+import React, { Component } from 'react'
+
+export default function uncontrolled (Component, {defaultProp, prop, handler, reset}) {
+  return class Uncontrolled extends Component {
+    componentDidMount () {
+      this.setState({
+        [prop]: this.props[prop] != null
+          ? this.props[prop] || ''
+          : this.props[defaultProp]
+      })
+    }
+
+    handleHandler (handler, e) {
+      if (this.props[prop] != null) {
+        handler && handler(e)
+      } else {
+        this.setState({
+          [prop]: e && e.target
+            ? e.target.value
+            : e
+        })
+
+        handler && handler(e)
+      }
+    }
+
+    handleReset (handler, e) {
+      if (this.props[prop] != null) {
+        handler && handler(e)
+      } else {
+        this.setState({
+          [prop]: undefined
+        })
+
+        handler && handler(e)
+      }
+    }
+
+    render () {
+      const consumerHandler = this.props[handler]
+      const consumerReset = this.props[reset]
+
+      const props = Object.keys(this.props)
+        .filter(key => key !== handler)
+        .reduce((filteredProps, key) => ({
+          ...filteredProps,
+          [key]: this.props[key]
+        }), {})
+
+      const handlerProps = {
+        [handler]: this.handleHandler.bind(this, consumerHandler),
+        [reset]: this.handleReset.bind(this, consumerReset)
+      }
+
+      return <Component
+        {...props}
+        {...this.state}
+        {...handlerProps}
+      />
+    }
+  }
+}

--- a/decorators/uncontrolled.jsx
+++ b/decorators/uncontrolled.jsx
@@ -41,7 +41,7 @@ export default function uncontrolled (Component, {defaultProp, prop, handler, re
       const consumerReset = this.props[reset]
 
       const props = Object.keys(this.props)
-        .filter(key => key !== handler)
+        .filter((key) => key !== handler)
         .reduce((filteredProps, key) => ({
           ...filteredProps,
           [key]: this.props[key]

--- a/decorators/uncontrolled.jsx
+++ b/decorators/uncontrolled.jsx
@@ -11,29 +11,25 @@ export default function uncontrolled (Component, {defaultProp, prop, handler, re
     }
 
     handleHandler (handler, e) {
-      if (this.props[prop] != null) {
-        handler && handler(e)
-      } else {
+      if (this.props[prop] == null) {
         this.setState({
           [prop]: e && e.target
             ? e.target.value
             : e
         })
-
-        handler && handler(e)
       }
+      
+      handler && handler(e)
     }
 
     handleReset (handler, e) {
-      if (this.props[prop] != null) {
-        handler && handler(e)
-      } else {
+      if (this.props[prop] == null) {
         this.setState({
           [prop]: undefined
         })
-
-        handler && handler(e)
       }
+
+      handler && handler(e)
     }
 
     render () {

--- a/decorators/uncontrolled.jsx
+++ b/decorators/uncontrolled.jsx
@@ -18,7 +18,7 @@ export default function uncontrolled (Component, {defaultProp, prop, handler, re
             : e
         })
       }
-      
+
       handler && handler(e)
     }
 
@@ -33,25 +33,31 @@ export default function uncontrolled (Component, {defaultProp, prop, handler, re
     }
 
     render () {
-      const consumerHandler = this.props[handler]
-      const consumerReset = this.props[reset]
+      const props = Object.keys(this.props).reduce((handledProps, key) => {
+        switch (key) {
+          case handler:
+            return {
+              ...handledProps,
+              [handler]: this.handleHandler.bind(this, this.props[handler])
+            }
 
-      const props = Object.keys(this.props)
-        .filter((key) => key !== handler)
-        .reduce((filteredProps, key) => ({
-          ...filteredProps,
-          [key]: this.props[key]
-        }), {})
+          case reset:
+            return {
+              ...handledProps,
+              [reset]: this.handleReset.bind(this, this.props[reset])
+            }
 
-      const handlerProps = {
-        [handler]: this.handleHandler.bind(this, consumerHandler),
-        [reset]: this.handleReset.bind(this, consumerReset)
-      }
+          default:
+            return {
+              ...handledProps,
+              [key]: this.props[key]
+            }
+        }
+      }, {})
 
       return <Component
         {...props}
         {...this.state}
-        {...handlerProps}
       />
     }
   }


### PR DESCRIPTION
This is **Part 1** of the saga of moving towards [controlled vs uncontrolled](https://github.com/klarna/ui/issues/45) being a consequence of the provided props instead of a feature of the component. This HOC allows for converting a fully controlled set of props in component into pseudo controlled. The typical case would look like this:

```js
import Field from '@klarna/ui/Field'
import uncontrolled from '@klarna/ui/decorators/uncontrolled'

export default uncontrolled(Field, {
  prop: 'value',
  defaultProp: 'defaulValue',
  handler: 'onChange'
})
```

It will also work for making focus pseudo controlled like:

```js
import Field from '@klarna/ui/Field'

export default uncontrolled(Field, {
  prop: 'focus',
  defaultProp: 'autoFocus',
  handler: 'onFocus',
  reset: 'onBlur'
})
```

Merging this is completely safe since it's not yet used, but I'm planning on setting this as the default for Templates so that consumption of those is easier and it would be nice to get feedback on what you think of this approach.