### PR TITLE
Style input placeholder

### DIFF
--- a/Field/styles.scss
+++ b/Field/styles.scss
@@ -183,6 +183,18 @@
     @include typography(map-get($font-sizes, big-body-desktop), semi-bold);
   }
 
+  &::-webkit-input-placeholder {
+    // This should be the same color and font weight as .field__label.
+    color: map-get($colors, grey-text);
+    font-weight: normal;
+  }
+
+  &:-ms-input-placeholder {
+    // This should be the same color and font weight as .field__label.
+    color: map-get($colors, grey-text);
+    font-weight: normal;
+  }
+
   // Disable clear field icon for IE10+
   &::-ms-clear {
     height: 0;

--- a/Input/styles.scss
+++ b/Input/styles.scss
@@ -278,6 +278,18 @@ $stackable-border-width: $grid * .2;
     @include typography(map-get($font-sizes, big-body-desktop), semi-bold);
   }
 
+  &::-webkit-input-placeholder {
+    // This should be the same color and font weight as .input__label.
+    color: map-get($colors, grey-text);
+    font-weight: normal;
+  }
+
+  &:-ms-input-placeholder {
+    // This should be the same color and font weight as .input__label.
+    color: map-get($colors, grey-text);
+    font-weight: normal;
+  }
+
   // Disable clear field icon for IE10+
   &::-ms-clear {
     height: 0;


### PR DESCRIPTION
In order for us to start using the native placeholder as a compliment to the label, it needs to be styled to look like the label.