### PR TITLE
Swipable switch

### DIFF
--- a/Switch/Toggle/index.jsx
+++ b/Switch/Toggle/index.jsx
@@ -9,11 +9,90 @@ const classes = {
   bullet: `${baseClass}__bullet`,
   bulletToggle: `${baseClass}__bullet__toggle`,
   label: `${baseClass}__label`,
-  input: `${baseClass}__input`
+  input: `${baseClass}__input`,
+  container: `${baseClass}__container`
 }
 
-const press = (component) => () => component.setState({ pressed: true })
-const release = (component) => () => component.setState({ pressed: false })
+const pressMouse = (component) => () => component.setState({ pressed: true })
+const releaseMouse = (component) => () => component.setState({ pressed: false })
+const pressTouch = (component) => (e) => {
+  component.setState({
+    pressed: true,
+    touchStartPositionX: e.changedTouches[0].pageX
+  })
+}
+const releaseTouch = (component) => (e) => {
+  const { touchStartPositionX } = component.state
+  const touchPositionX = e.changedTouches[0].pageX
+  const { value } = component.props
+
+  if (touchStartPositionX < touchPositionX && !value) {
+    component.props.onChange && component.props.onChange(true)
+
+  } else if (touchStartPositionX > touchPositionX && value) {
+    component.props.onChange && component.props.onChange(false)
+  }
+
+  if (!component.props.focus) {
+    component.props.onFocus && component.props.onFocus()
+  }
+
+  component.setState({
+    pressed: false,
+    touchPositionX: undefined,
+    touchStartPositionX: undefined,
+    pseudoValue: undefined,
+    bulletPosition: undefined
+  })
+}
+const dragTouch = (component) => (e) => {
+  const { position, pseudoValue } = getRelativeOffset(component, e.changedTouches[0].pageX)
+  component.setState({
+    bulletPosition: position,
+    pseudoValue,
+    touchPositionX: e.changedTouches[0].pageX
+  })
+}
+
+const bulletStyles = (component, customize, xOffset) => {
+  if (!customize && xOffset == null) {
+    return undefined
+  }
+
+  const { touchStartPositionX, bulletPosition } = component.state
+
+  return {
+    ...(customize ? { backgroundColor: customize.bulletColor } : {}),
+    ...(xOffset != null ? {
+      transform: `translateX(${bulletPosition}px)`,
+      WebkitTransform: `translateX(${bulletPosition}px)`
+    } : {})
+  }
+}
+
+const getRelativeOffset = (component, touchPositionX) => {
+  const bulletWidth = component.refs.bulletToggle.getBoundingClientRect().width
+  const switchPosition = component.refs.bullet.getBoundingClientRect()
+  const relativePosition = touchPositionX - switchPosition.left
+  const borderOffset = 1
+
+  if (relativePosition < 0) {
+    return {
+      position: 0,
+      pseudoValue: false
+    }
+  } else if ((relativePosition + bulletWidth + borderOffset) > switchPosition.width) {
+    return {
+      position: switchPosition.width - bulletWidth - borderOffset * 2,
+      pseudoValue: true
+    }
+  }
+
+  return {
+    position: relativePosition - bulletWidth / 2,
+    pseudoValue: undefined
+  }
+}
 
 export const alignments = ['left', 'right']
 
@@ -64,7 +143,9 @@ const Toggle = React.createClass({
   },
 
   getInitialState () {
-    return { pressed: false }
+    return {
+      pressed: false
+    }
   },
 
   render () {
@@ -86,11 +167,11 @@ const Toggle = React.createClass({
       ...remainingProps
     } = this.props
 
-    const { pressed } = this.state
+    const { pressed, pseudoValue } = this.state
 
     const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
     const cls = classNames(baseClass, {
-      'is-checked': value,
+      'is-checked': pseudoValue != null ? pseudoValue : value,
       'is-focused': focus,
       'is-pressed': pressed,
       'is-disabled': disabled,
@@ -99,8 +180,11 @@ const Toggle = React.createClass({
       legal
     }, className)
 
-    const onMouseDown = !disabled && press(this)
-    const onMouseUp = !disabled && release(this)
+    const onMouseDown = !disabled && pressMouse(this)
+    const onMouseUp = !disabled && releaseMouse(this)
+    const onTouchStart = !disabled && pressTouch(this)
+    const onTouchEnd = !disabled && releaseTouch(this)
+    const onTouchMove = !disabled && dragTouch(this)
 
     return (<div
       className={cls}
@@ -123,20 +207,28 @@ const Toggle = React.createClass({
         htmlFor={name}
         style={customize ? {
           color: customize.textColor
-        } : undefined}>
+        } : undefined}
+        onTouchStart={onTouchStart}
+        onTouchEnd={onTouchEnd}
+        onTouchMove={onTouchMove}>
         <div
-          className={classNames(classes.bullet)}
-          style={customize && value ? {
-            backgroundColor: customize.backgroundColor,
-            borderColor: customize.backgroundColor
-          } : undefined}
-        />
-        <div
-          className={classNames(classes.bulletToggle)}
-          style={customize ? {
-            backgroundColor: customize.bulletColor
-          } : undefined}
-        />
+          className={classNames(classes.container)}
+        >
+          <div
+            className={classNames(classes.bullet)}
+            style={customize && value ? {
+              backgroundColor: customize.backgroundColor,
+              borderColor: customize.backgroundColor
+            } : undefined}
+            ref='bullet'
+          >
+            <div
+              className={classNames(classes.bulletToggle)}
+              style={bulletStyles(this, customize, this.state.touchPositionX)}
+              ref='bulletToggle'
+            />
+          </div>
+        </div>
         {children}
       </label>
     </div>)

--- a/Switch/Toggle/index.jsx
+++ b/Switch/Toggle/index.jsx
@@ -54,7 +54,7 @@ const dragTouch = (component) => (e) => {
 }
 
 const bulletStyles = (component, customize, xOffset) => {
-  if (!customize && xOffset == null) {
+  if (!customize && xOffset === undefined) {
     return undefined
   }
 
@@ -62,7 +62,7 @@ const bulletStyles = (component, customize, xOffset) => {
 
   return {
     ...(customize ? { backgroundColor: customize.bulletColor } : {}),
-    ...(xOffset != null ? {
+    ...(xOffset !== undefined ? {
       transform: `translateX(${bulletPosition}px)`,
       WebkitTransform: `translateX(${bulletPosition}px)`
       msTransform: `translateX(${bulletPosition}px)`
@@ -171,7 +171,7 @@ const Toggle = React.createClass({
 
     const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
     const cls = classNames(baseClass, {
-      'is-checked': pseudoValue != null ? pseudoValue : value,
+      'is-checked': pseudoValue !== undefined ? pseudoValue : value,
       'is-focused': focus,
       'is-pressed': pressed,
       'is-disabled': disabled,

--- a/Switch/Toggle/index.jsx
+++ b/Switch/Toggle/index.jsx
@@ -28,7 +28,6 @@ const releaseTouch = (component) => (e) => {
 
   if (touchStartPositionX < touchPositionX && !value) {
     component.props.onChange && component.props.onChange(true)
-
   } else if (touchStartPositionX > touchPositionX && value) {
     component.props.onChange && component.props.onChange(false)
   }
@@ -59,7 +58,7 @@ const bulletStyles = (component, customize, xOffset) => {
     return undefined
   }
 
-  const { touchStartPositionX, bulletPosition } = component.state
+  const { bulletPosition } = component.state
 
   return {
     ...(customize ? { backgroundColor: customize.bulletColor } : {}),

--- a/Switch/Toggle/index.jsx
+++ b/Switch/Toggle/index.jsx
@@ -64,7 +64,7 @@ const bulletStyles = (component, customize, xOffset) => {
     ...(customize ? { backgroundColor: customize.bulletColor } : {}),
     ...(xOffset !== undefined ? {
       transform: `translateX(${bulletPosition}px)`,
-      WebkitTransform: `translateX(${bulletPosition}px)`
+      WebkitTransform: `translateX(${bulletPosition}px)`,
       msTransform: `translateX(${bulletPosition}px)`
     } : {})
   }

--- a/Switch/Toggle/index.jsx
+++ b/Switch/Toggle/index.jsx
@@ -65,6 +65,7 @@ const bulletStyles = (component, customize, xOffset) => {
     ...(xOffset != null ? {
       transform: `translateX(${bulletPosition}px)`,
       WebkitTransform: `translateX(${bulletPosition}px)`
+      msTransform: `translateX(${bulletPosition}px)`
     } : {})
   }
 }

--- a/Switch/Toggle/styles.scss
+++ b/Switch/Toggle/styles.scss
@@ -56,13 +56,24 @@
   }
 }
 
+.switch__container {
+  position: absolute;
+  left: 0;
+  top: 0;
+
+  .right & {
+    left: auto;
+    right: 0;
+  }
+}
+
 .switch__bullet {
   background: map-get($colors, grey-text);
   border-radius: ($grid * 4);
   cursor: pointer;
   height: ($grid * 4.4);
   left: 0;
-  position: absolute;
+  position: relative;
   top: ($grid * .8);
   transition: all .2s ease;
   width: ($grid * 7.4);
@@ -86,40 +97,11 @@
   height: ($grid * 4);
   left: ($grid * .2);
   position: absolute;
-  top: ($grid * 1);
+  top: ($grid * .2);
   transition: all .2s ease;
   width: ($grid * 4);
 
-  .is-pressed & {
-    width: ($grid * 5);
-  }
-
   .is-checked & {
-    left: ($grid * 3.2);
-  }
-
-  .is-pressed.is-checked & {
-    left: ($grid * 2.2);
-    width: ($grid * 5);
-  }
-
-  .right & {
-    left: auto;
-    right: ($grid * 3.2);
-  }
-
-  .right.is-pressed & {
-    left: auto;
-    right: ($grid * 2.2);
-  }
-
-  .right.is-checked & {
-    left: auto;
-    right: ($grid * .2);
-  }
-
-  .right.is-pressed.is-checked & {
-    left: auto;
-    right: ($grid * .2);
+    transform: translateX($grid * 3);
   }
 }

--- a/Switch/Toggle/styles.scss
+++ b/Switch/Toggle/styles.scss
@@ -57,8 +57,8 @@
 }
 
 .switch__container {
-  position: absolute;
   left: 0;
+  position: absolute;
   top: 0;
 
   .right & {


### PR DESCRIPTION
![swipeable-switch](https://cloud.githubusercontent.com/assets/83586/19520479/b385610e-9610-11e6-8287-6d95e42405b3.gif)

The code isn't the most beautiful thing I've ever written, but it works quite well. Feels A LOT better now than it did before.

The current implementation allows you to start swiping anywhere on the label or the bullet, because the bullet by itself is a rather small target.

Something to consider:

* We had an off-by-one error where you could swipe it 1px "too far", and then it would snap back to the right edge when you let go. I actually felt like this felt really good and tactile, but I'm not sure if that's the direction we want to go with these components.