### PR TITLE
(WIP) Add calendar icon

### DIFF
--- a/icons/Calendar.jsx
+++ b/icons/Calendar.jsx
@@ -1,0 +1,44 @@
+import React, { PropTypes } from 'react'
+import classNamesBind from 'classnames/bind'
+import defaultStyles from './styles.scss'
+import colors from './constants/colors'
+
+export default function Calendar ({ color, styles, className, ...props }) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+
+  return (
+    <svg
+      className={classNames('illustration', 'tiny', color, className)}
+      viewBox='0 0 20 20'
+      height='20px'
+      width='20px'
+      {...props}>
+      <rect
+        className={classNames('illustration__stroke')}
+        x='3'
+        y='4'
+        width='14'
+        height='12'
+        rx='3' />
+      <path
+        d='M3.5,8.5 L16.5,8.5'
+        className={classNames('illustration__stroke')} />
+      <path
+        d='M6.5,2.5 L6.5,5.5'
+        className={classNames('illustration__stroke')} />
+      <path
+        d='M13.5,2.5 L13.5,5.5'
+        className={classNames('illustration__stroke')} />
+    </svg>
+  )
+}
+
+Calendar.defaultProps = {
+  color: 'blue',
+  styles: {}
+}
+
+Calendar.propTypes = {
+  color: PropTypes.oneOf(colors),
+  styles: PropTypes.object
+}

--- a/icons/example.jsx
+++ b/icons/example.jsx
@@ -4,6 +4,7 @@ import { LIVE } from '../Showroom/variationTypes'
 
 import AccountActivated from '../icons/AccountActivated'
 import AllSet from '../icons/AllSet'
+import Calendar from '../icons/Calendar'
 import * as Chevron from '../icons/Chevron'
 import Checkmark from '../icons/Checkmark'
 import Done from '../icons/Done'
@@ -53,6 +54,7 @@ const icons = {
     Chevron.Right,
     Chevron.Down,
     Chevron.Up,
+    Calendar,
     Checkmark,
     Details,
     Download,

--- a/icons/index.jsx
+++ b/icons/index.jsx
@@ -1,5 +1,6 @@
 export { default as AccountActivated } from './AccountActivated'
 export { default as AllSet } from './AllSet'
+export { default as Calendar } from './Calendar'
 export { default as Chevron } from './Chevron'
 export { default as Cancel } from './Cancel'
 export { default as Checkmark } from './Checkmark'


### PR DESCRIPTION
For the upcoming date picker we need a calendar icon.
@hankatt Did we need to update the design any?

Preview of the showroom tiny section:
![calendar-icon](https://cloud.githubusercontent.com/assets/895361/19521952/d5ae6ad2-9615-11e6-8c87-7fc6660241f7.png)
