### PR TITLE
Radio button tweaks

### DIFF
--- a/Radio/example.jsx
+++ b/Radio/example.jsx
@@ -30,6 +30,14 @@ import UncontrolledRadio from '@klarna/ui/uncontrolled/Radio'`,
         options={options}
       />,
 
+      Borderfull: <Radio
+        borderfull
+        name='radio-borderfull'
+        onChange={(key) => console.log(key)}
+        options={options}
+        value='lorem'
+      />,
+
       Borderless: <Radio
         borderless
         name='radio-borderless'

--- a/Radio/example.jsx
+++ b/Radio/example.jsx
@@ -30,9 +30,9 @@ import UncontrolledRadio from '@klarna/ui/uncontrolled/Radio'`,
         options={options}
       />,
 
-      Borderfull: <Radio
-        borderfull
-        name='radio-borderfull'
+      Borderful: <Radio
+        borderful
+        name='radio-borderful'
         onChange={(key) => console.log(key)}
         options={options}
         value='lorem'

--- a/Radio/index.jsx
+++ b/Radio/index.jsx
@@ -17,6 +17,8 @@ export default React.createClass({
   displayName: 'Radio',
 
   propTypes: {
+    borderfull: PropTypes.bool,
+    borderless: PropTypes.bool,
     className: PropTypes.string,
     disabled: PropTypes.bool,
     focus: PropTypes.string,

--- a/Radio/index.jsx
+++ b/Radio/index.jsx
@@ -17,7 +17,7 @@ export default React.createClass({
   displayName: 'Radio',
 
   propTypes: {
-    borderfull: PropTypes.bool,
+    borderful: PropTypes.bool,
     borderless: PropTypes.bool,
     className: PropTypes.string,
     disabled: PropTypes.bool,
@@ -51,7 +51,7 @@ export default React.createClass({
 
   render () {
     const {
-      borderfull,
+      borderful,
       borderless,
       className,
       focus,
@@ -71,7 +71,7 @@ export default React.createClass({
     return (
       <div
         className={classNames(baseClass, {
-          borderfull,
+          borderful,
           borderless,
           'is-disabled': disabled,
           'is-focused': focus != null

--- a/Radio/index.jsx
+++ b/Radio/index.jsx
@@ -49,6 +49,7 @@ export default React.createClass({
 
   render () {
     const {
+      borderfull,
       borderless,
       className,
       focus,
@@ -68,6 +69,7 @@ export default React.createClass({
     return (
       <div
         className={classNames(baseClass, {
+          borderfull,
           borderless,
           'is-disabled': disabled,
           'is-focused': focus != null

--- a/Radio/styles.scss
+++ b/Radio/styles.scss
@@ -60,10 +60,10 @@
   }
 
   &:last-child {
+    border-bottom: none;
     border-bottom-left-radius: $border-radius;
     border-bottom-right-radius: $border-radius;
     padding-bottom: ($grid * 3.2);
-    border-bottom: none;
   }
 
   .borderless & {

--- a/Radio/styles.scss
+++ b/Radio/styles.scss
@@ -49,11 +49,6 @@
   transition: all .2s ease;
   user-select: none;
 
-  &:hover,
-  &.is-focused {
-    background: map-get($colors, block-hover);
-  }
-
   &:first-of-type {
     border-top-left-radius: $border-radius;
     border-top-right-radius: $border-radius;

--- a/Radio/styles.scss
+++ b/Radio/styles.scss
@@ -37,7 +37,6 @@
 }
 
 .radio__option {
-  background: white;
   cursor: pointer;
   display: block;
   overflow: hidden;
@@ -51,6 +50,15 @@
 
   .borderful & {
     border-bottom: ($grid * .2) solid $border-color-inner;
+    margin-top: ($grid * -.2);
+
+    &:first-of-type {
+      margin-top: 0;
+    }
+
+    &:last-child {
+      border-bottom: none;
+    }
   }
 
   &:first-of-type {
@@ -60,7 +68,6 @@
   }
 
   &:last-child {
-    border-bottom: none;
     border-bottom-left-radius: $border-radius;
     border-bottom-right-radius: $border-radius;
     padding-bottom: ($grid * 3.2);

--- a/Radio/styles.scss
+++ b/Radio/styles.scss
@@ -49,6 +49,10 @@
   transition: all .2s ease;
   user-select: none;
 
+  .borderfull & {
+    border-bottom: ($grid * .2) solid $border-color-inner;
+  }
+
   &:first-of-type {
     border-top-left-radius: $border-radius;
     border-top-right-radius: $border-radius;
@@ -59,6 +63,7 @@
     border-bottom-left-radius: $border-radius;
     border-bottom-right-radius: $border-radius;
     padding-bottom: ($grid * 3.2);
+    border-bottom: none;
   }
 
   .borderless & {

--- a/Radio/styles.scss
+++ b/Radio/styles.scss
@@ -49,7 +49,7 @@
   transition: all .2s ease;
   user-select: none;
 
-  .borderfull & {
+  .borderful & {
     border-bottom: ($grid * .2) solid $border-color-inner;
   }
 

--- a/css/settings.scss
+++ b/css/settings.scss
@@ -110,6 +110,7 @@ $font-sizes: (
 $border-radius: $grid;
 $border-radius-checkbox: ($grid * .4);
 $border-color: map-get($colors, grey-lines);
+$border-color-inner: map-get($colors, light-grey);
 
 // ================================================================
 //  General webkit autocomplete override (aka yellow background)


### PR DESCRIPTION
This PR does two changes:

- Removes the hover state that would highlight the backgroud as gray;
- Add a new option `borderfull` to add borders between options.