### PR TITLE
React and ReactMotion should be peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
   "dependencies": {
     "classnames": "2.2.5",
     "parse-color": "1.0.0",
-    "react": "^15.0.2",
-    "react-context-props": "^0.1.4",
-    "react-motion": "0.4.2"
+    "react-context-props": "^0.1.4"
   },
   "devDependencies": {
     "autoprefixer": "^6.4.1",
@@ -80,6 +78,10 @@
     "webpack-error-notification": "^0.1.6",
     "yargs": "^3.31.0",
     "zen-router": "^1.0.0"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0",
+    "react-motion": "^0.4.2"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
Otherwise we might bundle two distinct versions of React due to the way npm installs dependencies.