### PR TITLE
Make components overridable

### DIFF
--- a/Button/Primary/index.jsx
+++ b/Button/Primary/index.jsx
@@ -2,10 +2,12 @@ import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import Loader from '../../Loader'
 import contains from '../../lib/contains'
+import compose from '../../lib/compose'
 import defaultStyles from '../styles.scss'
 import parseColor from 'parse-color'
 import Price from '../Price'
 import themeable from '../../decorators/themeable'
+import overridable from '../../decorators/overridable'
 
 const baseClass = 'button'
 
@@ -100,11 +102,14 @@ Primary.propTypes = {
   styles: PropTypes.object
 }
 
-export default themeable(Primary, (customizations, { customize }) => ({
-  customize: {
-    ...customize,
-    backgroundColor: customizations.color_button,
-    borderRadius: customizations.radius_border,
-    textColor: customizations.color_button_text
-  }
-}))
+export default compose(
+  themeable((customizations, { customize }) => ({
+    customize: {
+      ...customize,
+      backgroundColor: customizations.color_button,
+      borderRadius: customizations.radius_border,
+      textColor: customizations.color_button_text
+    }
+  })),
+  overridable(defaultStyles)
+)(Primary)

--- a/Button/Secondary/index.jsx
+++ b/Button/Secondary/index.jsx
@@ -4,7 +4,9 @@ import Price from '../Price'
 import classNamesBind from 'classnames/bind'
 import parseColor from 'parse-color'
 import contains from '../../lib/contains'
+import compose from '../../lib/compose'
 import themeable from '../../decorators/themeable'
+import overridable from '../../decorators/overridable'
 import defaultStyles from '../styles.scss'
 
 const baseClass = 'button'
@@ -117,11 +119,14 @@ Secondary.propTypes = {
   styles: PropTypes.object
 }
 
-export default themeable(Secondary, (customizations, { customize }) => ({
-  customize: {
-    ...customize,
-    backgroundColor: customizations.color_button,
-    borderRadius: customizations.radius_border,
-    textColor: customizations.color_button_text
-  }
-}))
+export default compose(
+  themeable((customizations, { customize }) => ({
+    customize: {
+      ...customize,
+      backgroundColor: customizations.color_button,
+      borderRadius: customizations.radius_border,
+      textColor: customizations.color_button_text
+    }
+  })),
+  overridable(defaultStyles)
+)(Secondary)

--- a/Button/Tertiary/index.jsx
+++ b/Button/Tertiary/index.jsx
@@ -4,7 +4,9 @@ import Price from '../Price'
 import classNamesBind from 'classnames/bind'
 import parseColor from 'parse-color'
 import contains from '../../lib/contains'
+import compose from '../../lib/compose'
 import themeable from '../../decorators/themeable'
+import overridable from '../../decorators/overridable'
 import defaultStyles from '../styles.scss'
 
 const baseClass = 'button'
@@ -117,11 +119,15 @@ Tertiary.propTypes = {
   styles: PropTypes.object
 }
 
-export default themeable(Tertiary, (customizations, { customize }) => ({
-  customize: {
-    ...customize,
-    backgroundColor: customizations.color_button,
-    borderRadius: customizations.radius_border,
-    textColor: customizations.color_button_text
-  }
-}))
+export default compose(
+  themeable((customizations, { customize }) => ({
+    customize: {
+      ...customize,
+      backgroundColor: customizations.color_button,
+      borderRadius: customizations.radius_border,
+      textColor: customizations.color_button_text
+    }
+  })),
+  overridable(defaultStyles)
+)(Tertiary)
+

--- a/Checklist/index.jsx
+++ b/Checklist/index.jsx
@@ -1,6 +1,8 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import themeable from '../decorators/themeable'
+import overridable from '../decorators/overridable'
+import compose from '../lib/compose'
 import defaultStyles from './styles.scss'
 
 const baseClass = 'checklist'
@@ -42,13 +44,16 @@ ChecklistMain.propTypes = {
   })
 }
 
-export const Main = themeable(ChecklistMain, (customizations, props) => ({
-  customize: {
-    ...props.customize,
-    borderColor: customizations.color_border,
-    borderRadius: customizations.radius_border
-  }
-}))
+export const Main = compose(
+  themeable((customizations, props) => ({
+    customize: {
+      ...props.customize,
+      borderColor: customizations.color_border,
+      borderRadius: customizations.radius_border
+    }
+  })),
+  overridable(defaultStyles)
+)(ChecklistMain)
 
 function ChecklistItem ({ className, children, customize, styles }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
@@ -87,10 +92,13 @@ ChecklistItem.propTypes = {
   })
 }
 
-export const Item = themeable(ChecklistItem, (customizations, props) => ({
-  customize: {
-    ...props.customize,
-    strokeColor: customizations.color_details,
-    textColor: customizations.color_text
-  }
-}))
+export const Item = compose(
+  themeable((customizations, props) => ({
+    customize: {
+      ...props.customize,
+      strokeColor: customizations.color_details,
+      textColor: customizations.color_text
+    }
+  })),
+  overridable(defaultStyles)
+)(ChecklistItem)

--- a/Dropdown/index.jsx
+++ b/Dropdown/index.jsx
@@ -6,8 +6,10 @@ import * as fieldStates from '../lib/features/fieldStates'
 import * as inlinedIcon from '../lib/features/inlinedIcon'
 import * as stacking from '../lib/features/stacking'
 import { handleKeyDown } from '../lib/features/keyboardEvents'
+import compose from '../lib/compose'
 import MouseflowExclude from '../MouseflowExclude'
 import themeable from '../decorators/themeable'
+import overridable from '../decorators/overridable'
 
 const baseClass = 'dropdown'
 
@@ -225,13 +227,16 @@ const onMouseLeave = (component) => () =>
     hover: false
   })
 
-export default themeable(Dropdown, (customizations, props) => ({
-  customize: {
-    ...props.customize,
-    borderColor: customizations.color_border,
-    borderColorSelected: customizations.color_border_selected,
-    borderRadius: customizations.radius_border,
-    labelColor: customizations.color_text_secondary,
-    selectedColor: customizations.color_text
-  }
-}))
+export default compose(
+  themeable((customizations, props) => ({
+    customize: {
+      ...props.customize,
+      borderColor: customizations.color_border,
+      borderColorSelected: customizations.color_border_selected,
+      borderRadius: customizations.radius_border,
+      labelColor: customizations.color_text_secondary,
+      selectedColor: customizations.color_text
+    }
+  })),
+  overridable(defaultStyles)
+)(Dropdown)

--- a/Field/index.jsx
+++ b/Field/index.jsx
@@ -6,8 +6,10 @@ import * as fieldStates from '../lib/features/fieldStates'
 import * as inlinedIcon from '../lib/features/inlinedIcon'
 import * as stacking from '../lib/features/stacking'
 import { handleKeyDown } from '../lib/features/keyboardEvents'
+import compose from '../lib/compose'
 import MouseflowExclude from '../MouseflowExclude'
 import themeable from '../decorators/themeable'
+import overridable from '../decorators/overridable'
 
 const baseClass = 'field'
 
@@ -223,13 +225,16 @@ const Field = React.createClass({
   }
 })
 
-export default themeable(Field, (customizations, props) => ({
-  customize: {
-    ...props.customize,
-    borderColor: customizations.color_border,
-    borderColorSelected: customizations.color_border_selected,
-    borderRadius: customizations.radius_border,
-    labelColor: customizations.color_text_secondary,
-    inputColor: customizations.color_text
-  }
-}))
+export default compose(
+  themeable((customizations, props) => ({
+    customize: {
+      ...props.customize,
+      borderColor: customizations.color_border,
+      borderColorSelected: customizations.color_border_selected,
+      borderRadius: customizations.radius_border,
+      labelColor: customizations.color_text_secondary,
+      inputColor: customizations.color_text
+    }
+  })),
+  overridable(defaultStyles)
+)(Field)

--- a/IconButton/Back/index.jsx
+++ b/IconButton/Back/index.jsx
@@ -1,6 +1,8 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import themeable from '../../decorators/themeable'
+import overridable from '../../decorators/overridable'
+import compose from '../../lib/compose'
 import defaultStyles from '../styles.scss'
 
 const classes = {
@@ -37,6 +39,7 @@ Back.propTypes = {
   styles: PropTypes.object
 }
 
-export default themeable(Back, () => ({
-  color: 'gray'
-}))
+export default compose(
+  themeable(() => ({ color: 'gray' })),
+  overridable(defaultStyles)
+)(Back)

--- a/IconButton/Close/index.jsx
+++ b/IconButton/Close/index.jsx
@@ -1,6 +1,8 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import themeable from '../../decorators/themeable'
+import overridable from '../../decorators/overridable'
+import compose from '../../lib/compose'
 import defaultStyles from '../styles.scss'
 
 const classes = {
@@ -37,6 +39,7 @@ Close.propTypes = {
   styles: PropTypes.object
 }
 
-export default themeable(Close, () => ({
-  color: 'gray'
-}))
+export default compose(
+  themeable(() => ({ color: 'gray' })),
+  overridable(defaultStyles)
+)(Close)

--- a/IconButton/Hamburger/index.jsx
+++ b/IconButton/Hamburger/index.jsx
@@ -1,6 +1,8 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import themeable from '../../decorators/themeable'
+import overridable from '../../decorators/overridable'
+import compose from '../../lib/compose'
 import defaultStyles from '../styles.scss'
 
 const classes = {
@@ -39,6 +41,7 @@ Hamburger.propTypes = {
   styles: PropTypes.object
 }
 
-export default themeable(Hamburger, () => ({
-  color: 'gray'
-}))
+export default compose(
+  themeable(() => ({ color: 'gray' })),
+  overridable(defaultStyles)
+)(Hamburger)

--- a/IconButton/Options/index.jsx
+++ b/IconButton/Options/index.jsx
@@ -1,6 +1,8 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import themeable from '../../decorators/themeable'
+import overridable from '../../decorators/overridable'
+import compose from '../../lib/compose'
 import defaultStyles from '../styles.scss'
 
 const classes = {
@@ -37,6 +39,7 @@ Options.propTypes = {
   styles: PropTypes.object
 }
 
-export default themeable(Options, () => ({
-  color: 'gray'
-}))
+export default compose(
+  themeable(() => ({ color: 'gray' })),
+  overridable(defaultStyles)
+)(Options)

--- a/IconButton/Search/index.jsx
+++ b/IconButton/Search/index.jsx
@@ -1,6 +1,8 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import themeable from '../../decorators/themeable'
+import overridable from '../../decorators/overridable'
+import compose from '../../lib/compose'
 import defaultStyles from '../styles.scss'
 
 const classes = {
@@ -39,6 +41,7 @@ Search.propTypes = {
   styles: PropTypes.object
 }
 
-export default themeable(Search, () => ({
-  color: 'gray'
-}))
+export default compose(
+  themeable(() => ({ color: 'gray' })),
+  overridable(defaultStyles)
+)(Search)

--- a/Installments/index.jsx
+++ b/Installments/index.jsx
@@ -1,8 +1,10 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import themeable from '../decorators/themeable'
+import overridable from '../decorators/overridable'
 import defaultStyles from './styles.scss'
 import debounce from '../lib/debounce'
+import compose from '../lib/compose'
 
 const baseClass = 'installments'
 const TRANSITION_DURATION = 500
@@ -281,12 +283,15 @@ const cellDynamicStyles = ({ borderColor, borderColorSelected, labelColor }, hov
     ? { borderColor, color: borderColorSelected }
     : { borderColor, color: labelColor }
 
-export default themeable(Installments, (customizations, props) => ({
-  customize: {
-    ...props.customize,
-    borderColor: customizations.color_border,
-    borderColorSelected: customizations.color_border_selected,
-    borderRadius: customizations.radius_border,
-    labelColor: customizations.color_text
-  }
-}))
+export default compose(
+  themeable((customizations, props) => ({
+    customize: {
+      ...props.customize,
+      borderColor: customizations.color_border,
+      borderColorSelected: customizations.color_border_selected,
+      borderRadius: customizations.radius_border,
+      labelColor: customizations.color_text
+    }
+  })),
+  overridable(defaultStyles)
+)(Installments)

--- a/Link/index.jsx
+++ b/Link/index.jsx
@@ -2,7 +2,9 @@ import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
 import palette from '../lib/palette'
+import compose from '../lib/compose'
 import themeable from '../decorators/themeable'
+import overridable from '../decorators/overridable'
 
 const baseClass = 'link'
 
@@ -47,9 +49,12 @@ Link.propTypes = {
   styles: PropTypes.object
 }
 
-export default themeable(Link, (customizations, props) => ({
-  customize: {
-    ...props.customize,
-    textColor: customizations.color_link
-  }
-}))
+export default compose(
+  themeable((customizations, props) => ({
+    customize: {
+      ...props.customize,
+      textColor: customizations.color_link
+    }
+  })),
+  overridable(defaultStyles)
+)(Link)

--- a/List/Item/index.jsx
+++ b/List/Item/index.jsx
@@ -1,6 +1,8 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import themeable from '../../decorators/themeable'
+import overridable from '../../decorators/overridable'
+import compose from '../../lib/compose'
 import defaultStyles from '../styles.scss'
 
 const baseClass = 'list__item'
@@ -32,9 +34,12 @@ Item.propTypes = {
   styles: PropTypes.object
 }
 
-export default themeable(Item, (customizations, props) => ({
-  style: {
-    ...props.style,
-    color: customizations.color_text
-  }
-}))
+export default compose(
+  themeable((customizations, props) => ({
+    style: {
+      ...props.style,
+      color: customizations.color_text
+    }
+  })),
+  overridable(defaultStyles)
+)(Item)

--- a/Paragraph/Primary/index.jsx
+++ b/Paragraph/Primary/index.jsx
@@ -1,8 +1,10 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import themeable from '../../decorators/themeable'
+import overridable from '../../decorators/overridable'
 import defaultStyles from './styles.scss'
 import palette from '../../lib/palette'
+import compose from '../../lib/compose'
 
 const baseClass = 'paragraph--primary'
 
@@ -51,9 +53,12 @@ Primary.propTypes = {
   styles: PropTypes.object
 }
 
-export default themeable(Primary, (customizations, props) => ({
-  style: {
-    ...props.style,
-    color: customizations.color_text
-  }
-}))
+export default compose(
+  themeable((customizations, props) => ({
+    style: {
+      ...props.style,
+      color: customizations.color_text
+    }
+  })),
+  overridable(defaultStyles)
+)(Primary)

--- a/Paragraph/Secondary/index.jsx
+++ b/Paragraph/Secondary/index.jsx
@@ -1,8 +1,10 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import themeable from '../../decorators/themeable'
+import overridable from '../../decorators/overridable'
 import defaultStyles from './styles.scss'
 import palette from '../../lib/palette'
+import compose from '../../lib/compose'
 
 const baseClass = 'paragraph--secondary'
 
@@ -51,9 +53,12 @@ Secondary.propTypes = {
   styles: PropTypes.object
 }
 
-export default themeable(Secondary, (customizations, props) => ({
-  style: {
-    ...props.style,
-    color: customizations.color_text_secondary
-  }
-}))
+export default compose(
+  themeable((customizations, props) => ({
+    style: {
+      ...props.style,
+      color: customizations.color_text_secondary
+    }
+  })),
+  overridable(defaultStyles)
+)(Secondary)

--- a/Subtitle/index.jsx
+++ b/Subtitle/index.jsx
@@ -1,8 +1,10 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import themeable from '../decorators/themeable'
+import overridable from '../decorators/overridable'
 import defaultStyles from './styles.scss'
 import palette from '../lib/palette'
+import compose from '../lib/compose'
 
 const baseClass = 'subtitle'
 
@@ -49,9 +51,12 @@ Subtitle.propTypes = {
   styles: PropTypes.object
 }
 
-export default themeable(Subtitle, (customizations, props) => ({
-  style: {
-    ...props.style,
-    color: customizations.color_header
-  }
-}))
+export default compose(
+  themeable((customizations, props) => ({
+    style: {
+      ...props.style,
+      color: customizations.color_header
+    }
+  })),
+  overridable(defaultStyles)
+)(Subtitle)

--- a/Switch/Checkbox/index.jsx
+++ b/Switch/Checkbox/index.jsx
@@ -1,6 +1,8 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import themeable from '../../decorators/themeable'
+import overridable from '../../decorators/overridable'
+import compose from '../../lib/compose'
 import defaultStyles from './styles.scss'
 
 const baseClass = 'switch--checkbox'
@@ -159,12 +161,15 @@ const Checkbox = React.createClass({
   }
 })
 
-export default themeable(Checkbox, (customizations, props) => ({
-  customize: {
-    ...props.customize,
-    backgroundColor: customizations.color_checkbox,
-    bulletColor: customizations.color_checkbox_checkmark,
-    textColor: customizations.color_text,
-    borderColorSelected: customizations.color_border_selected
-  }
-}))
+export default compose(
+  themeable((customizations, props) => ({
+    customize: {
+      ...props.customize,
+      backgroundColor: customizations.color_checkbox,
+      bulletColor: customizations.color_checkbox_checkmark,
+      textColor: customizations.color_text,
+      borderColorSelected: customizations.color_border_selected
+    }
+  })),
+  overridable(defaultStyles)
+)(Checkbox)

--- a/Switch/Toggle/index.jsx
+++ b/Switch/Toggle/index.jsx
@@ -1,6 +1,8 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import themeable from '../../decorators/themeable'
+import overridable from '../../decorators/overridable'
+import compose from '../../lib/compose'
 import defaultStyles from './styles.scss'
 
 const baseClass = 'switch'
@@ -235,11 +237,14 @@ const Toggle = React.createClass({
   }
 })
 
-export default themeable(Toggle, (customizations, props) => ({
-  customize: {
-    ...props.customize,
-    backgroundColor: customizations.color_checkbox,
-    bulletColor: customizations.color_checkbox_checkmark,
-    textColor: customizations.color_text
-  }
-}))
+export default compose(
+  themeable((customizations, props) => ({
+    customize: {
+      ...props.customize,
+      backgroundColor: customizations.color_checkbox,
+      bulletColor: customizations.color_checkbox_checkmark,
+      textColor: customizations.color_text
+    }
+  })),
+  overridable(defaultStyles)
+)(Toggle)

--- a/Title/Primary/index.jsx
+++ b/Title/Primary/index.jsx
@@ -1,8 +1,10 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import themeable from '../../decorators/themeable'
+import overridable from '../../decorators/overridable'
 import defaultStyles from './styles.scss'
 import palette from '../../lib/palette'
+import compose from '../../lib/compose'
 
 const baseClass = 'title--primary'
 
@@ -57,9 +59,12 @@ Primary.propTypes = {
   styles: PropTypes.object
 }
 
-export default themeable(Primary, (customizations, props) => ({
-  style: {
-    ...props.style,
-    color: customizations.color_header
-  }
-}))
+export default compose(
+  themeable((customizations, props) => ({
+    style: {
+      ...props.style,
+      color: customizations.color_header
+    }
+  })),
+  overridable(defaultStyles)
+)(Primary)

--- a/Title/Secondary/index.jsx
+++ b/Title/Secondary/index.jsx
@@ -1,8 +1,10 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import themeable from '../../decorators/themeable'
+import overridable from '../../decorators/overridable'
 import defaultStyles from './styles.scss'
 import palette from '../../lib/palette'
+import compose from '../../lib/compose'
 
 const baseClass = 'title--secondary'
 
@@ -53,9 +55,12 @@ Secondary.propTypes = {
   styles: PropTypes.object
 }
 
-export default themeable(Secondary, (customizations, props) => ({
-  style: {
-    ...props.style,
-    color: customizations.color_header
-  }
-}))
+export default compose(
+  themeable((customizations, props) => ({
+    style: {
+      ...props.style,
+      color: customizations.color_header
+    }
+  })),
+  overridable(defaultStyles)
+)(Secondary)

--- a/decorators/overridable.jsx
+++ b/decorators/overridable.jsx
@@ -6,7 +6,7 @@ const overridable = (styles = {}, designName) => (Target) => {
     constructor (props) {
       super(props)
 
-      this.designName = designName ||  Target.displayName || Target.name
+      this.designName = designName || Target.displayName || Target.name
       this.Component = Target
     }
     componentWillMount () {
@@ -33,7 +33,7 @@ const overridable = (styles = {}, designName) => (Target) => {
     }
   }
 
-  OverridableComponent.displayName = `overridable(${Target.displayName || Target.name})`,
+  OverridableComponent.displayName = `overridable(${Target.displayName || Target.name})`
   OverridableComponent.defaultProps = {
     design: {},
     styles: {}

--- a/decorators/overridable.jsx
+++ b/decorators/overridable.jsx
@@ -30,7 +30,7 @@ const overridable = (styles = {}, designName) => (Target) => {
       }
     },
     render () {
-      const { design, ...otherProps } = this.props
+      const { design, ...otherProps } = this.props // eslint-disable-line
       const props = { ...otherProps, styles: this.styles }
       return <this.Component { ...props } />
     }

--- a/decorators/overridable.jsx
+++ b/decorators/overridable.jsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { withPropsFromContext } from 'react-context-props'
+
+const overridable = (styles = {}, designName) => (Target) => {
+  const OverridableComponent = React.createClass({
+    displayName: `overridable(${Target.displayName || Target.name})`,
+    designName: designName || Target.displayName || Target.name,
+    getDefaultProps () {
+      return {
+        design: {},
+        styles: {}
+      }
+    },
+    componentWillMount () {
+      this.styles = { ...styles, ...this.props.styles }
+      this.getAndSetOverride()
+    },
+    componentWillUpdate () {
+      this.getAndSetOverride()
+    },
+    getAndSetOverride () {
+      if (this.props.design.getOverrideFor) {
+        const override = this.props.design.getOverrideFor(
+          Object.assign(Target, { designName: this.designName })
+        )
+        this.Component = override.Component
+        this.styles = { ...this.styles, ...override.css }
+      } else {
+        this.Component = Target
+      }
+    },
+    render () {
+      const props = { ...this.props, styles: this.styles }
+      return <this.Component { ...props } />
+    }
+  })
+
+  return withPropsFromContext(
+    OverridableComponent,
+    ['design']
+  )
+}
+
+export default overridable

--- a/decorators/overridable.jsx
+++ b/decorators/overridable.jsx
@@ -30,7 +30,8 @@ const overridable = (styles = {}, designName) => (Target) => {
       }
     },
     render () {
-      const props = { ...this.props, styles: this.styles }
+      const { design, ...otherProps } = this.props
+      const props = { ...otherProps, styles: this.styles }
       return <this.Component { ...props } />
     }
   })

--- a/decorators/overridable.jsx
+++ b/decorators/overridable.jsx
@@ -2,39 +2,42 @@ import React from 'react'
 import { withPropsFromContext } from 'react-context-props'
 
 const overridable = (styles = {}, designName) => (Target) => {
-  const OverridableComponent = React.createClass({
-    displayName: `overridable(${Target.displayName || Target.name})`,
-    designName: designName || Target.displayName || Target.name,
-    getDefaultProps () {
-      return {
-        design: {},
-        styles: {}
-      }
-    },
+  class OverridableComponent extends React.Component {
+    constructor (props) {
+      super(props)
+
+      this.designName = designName ||  Target.displayName || Target.name
+      this.Component = Target
+    }
     componentWillMount () {
       this.styles = { ...styles, ...this.props.styles }
       this.getAndSetOverride()
-    },
+    }
     componentWillUpdate () {
       this.getAndSetOverride()
-    },
+    }
     getAndSetOverride () {
-      if (this.props.design.getOverrideFor) {
-        const override = this.props.design.getOverrideFor(
-          Object.assign(Target, { designName: this.designName })
-        )
-        this.Component = override.Component
-        this.styles = { ...this.styles, ...override.css }
-      } else {
-        this.Component = Target
+      if (!this.props.design.getOverrideFor) {
+        return
       }
-    },
+      const override = this.props.design.getOverrideFor(
+        Object.assign(Target, { designName: this.designName })
+      )
+      this.Component = override.Component
+      this.styles = { ...this.styles, ...override.css }
+    }
     render () {
       const { design, ...otherProps } = this.props // eslint-disable-line
       const props = { ...otherProps, styles: this.styles }
       return <this.Component { ...props } />
     }
-  })
+  }
+
+  OverridableComponent.displayName = `overridable(${Target.displayName || Target.name})`,
+  OverridableComponent.defaultProps = {
+    design: {},
+    styles: {}
+  }
 
   return withPropsFromContext(
     OverridableComponent,

--- a/decorators/themeable.jsx
+++ b/decorators/themeable.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { withPropsFromContext } from 'react-context-props'
 
-const themeable = (Target, adapter) => {
+const themeable = (adapter) => (Target) => {
   const ThemeableComponent = withPropsFromContext(
     ({ customizations, ...props }) => (
       <Target


### PR DESCRIPTION
In order for us to be able to override certain components' styles, or even override the entire component, we need to introduce a new `overridable` decorator. It does assume a couple of things, namely that a `design` object with a `getOverrideFor` method exists in the context.

The `getOverrideFor` method is expected to take a component and return an object with `css` and `Component`, where the `css` property is a CSS modules object and the `Component` is a React component.

This will be a breaking change if there are people using the `themeable` decorator directly in their projects.

Also, I only added it to the currently themeable components.