### PR TITLE
Disable installments cell highlight evens

### DIFF
--- a/Installments/styles.scss
+++ b/Installments/styles.scss
@@ -110,6 +110,7 @@ $highlightTransitionEasing: cubic-bezier(.31,.09,.24,1);
     border: ($grid * .4) solid map-get($colors, klarna-blue);
     border-radius: 5px;
     box-sizing: border-box;
+    cursor: pointer;
     display: block;
     left: -1px;
     opacity: 0;

--- a/Installments/styles.scss
+++ b/Installments/styles.scss
@@ -116,6 +116,7 @@ $highlightTransitionEasing: cubic-bezier(.31,.09,.24,1);
     position: absolute;
     top: -1px;
     z-index: 5;
+    pointer-events: none;
 
     @include respond-to-wide {
       height: ($grid * 15);

--- a/Installments/styles.scss
+++ b/Installments/styles.scss
@@ -113,10 +113,10 @@ $highlightTransitionEasing: cubic-bezier(.31,.09,.24,1);
     display: block;
     left: -1px;
     opacity: 0;
+    pointer-events: none;
     position: absolute;
     top: -1px;
     z-index: 5;
-    pointer-events: none;
 
     @include respond-to-wide {
       height: ($grid * 15);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klarna/ui",
-  "version": "1.17.4",
+  "version": "1.18.0",
   "description": "Klarna's UI Components",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Disable mouse interactions with the cell highlight element. The absolutely positioned highlight cell is preventing mouse interaction with the label element which is below it.