### PR TITLE
Add loading-state for the landing page

### DIFF
--- a/templates/chromes/Centered/index.jsx
+++ b/templates/chromes/Centered/index.jsx
@@ -22,6 +22,7 @@ export default function Centered ({
   children,
   labels,
   illustration,
+  loading,
   onAccept,
   onCancel,
   styles
@@ -49,6 +50,7 @@ export default function Centered ({
 
     {labels.accept && onAccept && <Button.Primary
       onClick={onAccept}
+      loading={loading}
       className={classNames(classes.buttonAccept)}>
       {labels.accept}
     </Button.Primary>}

--- a/templates/examples/Informative.jsx
+++ b/templates/examples/Informative.jsx
@@ -96,6 +96,35 @@ export default {
           </Wrapper>
         },
 
+        'With loading state': {
+          inline: <Landing
+            illustration={<DemoIcon />}
+            labels={{
+              title: 'Welcome to the site',
+              summary: 'Chia williamsburg subway tile vaporware, live-edge kinfolk cardigan prism deep v retro seitan.',
+              accept: 'Continue',
+              cancel: 'Go back'
+            }}
+            loading
+            onAccept={() => console.log('accept')}
+            onCancel={() => console.log('cancel')}
+          />,
+
+          wrapper: <Wrapper>
+            <Landing
+              illustration={<DemoIcon />}
+              labels={{
+                title: 'Welcome to the site',
+                summary: 'Chia williamsburg subway tile vaporware, live-edge kinfolk cardigan prism deep v retro seitan.',
+                accept: 'Continue',
+                cancel: 'Go back'
+              }}
+              onAccept={() => console.log('accept')}
+              onCancel={() => console.log('cancel')}
+            />
+          </Wrapper>
+        },
+
         'No Buttons': {
           inline: <Landing
             illustration={<DemoIcon />}


### PR DESCRIPTION
We need this to avoid clicking the button twice (clicking the button performs an HTTP POST in the authentication UI).

![landing-page-loading-state](https://cloud.githubusercontent.com/assets/569742/20093290/6ad78202-a59c-11e6-8ca3-6615a8240b19.gif)