### PR TITLE
Add placeholder and error styles for PinCode

### DIFF
--- a/Field/PinCode/index.jsx
+++ b/Field/PinCode/index.jsx
@@ -22,6 +22,7 @@ class PinCode extends PureComponent {
     const {
       className,
       customize,
+      error,
       length,
       onChange,
       style,
@@ -32,16 +33,22 @@ class PinCode extends PureComponent {
     const {focus, hover} = this.state
     const classNames = classNamesBind.bind({...defaultStyles, ...styles})
     const inputStyle = customize ? {
-      color: customize.inputColor,
-      borderColor: (hover || focus)
-        ? customize.borderColorSelected
-        : customize.borderColor,
+      ...(!error
+        ? {
+          color: customize.inputColor,
+          borderColor: (hover || focus)
+            ? customize.borderColorSelected
+            : customize.borderColor,
+          boxShadow: focus && `0 0 4px ${customize.borderColorSelected}`
+        }
+        : {}
+      ),
       borderRadius: customize.borderRadius,
-      boxShadow: focus && `0 0 4px ${customize.borderColorSelected}`
+      ...style
     } : style
 
     return <input
-      className={classNames(baseClass, className)}
+      className={classNames(baseClass, {error}, className)}
       onBlur={() => this.setState({focus: false})}
       onChange={onChange}
       onFocus={() => this.setState({focus: true})}
@@ -57,6 +64,7 @@ class PinCode extends PureComponent {
 }
 
 PinCode.defaultProps = {
+  error: false,
   length: 6,
   styles: {},
   value: ''
@@ -69,6 +77,7 @@ PinCode.propTypes = {
     borderRadius: PropTypes.string,
     inputColor: PropTypes.string
   }),
+  error: PropTypes.bool,
   length: PropTypes.number,
   onChange: PropTypes.func,
   placeholder: PropTypes.string,

--- a/Field/PinCode/index.jsx
+++ b/Field/PinCode/index.jsx
@@ -52,7 +52,7 @@ class PinCode extends PureComponent {
       type='tel'
       value={value}
       {...props}
-    />
+           />
   }
 }
 
@@ -71,6 +71,7 @@ PinCode.propTypes = {
   }),
   length: PropTypes.number,
   onChange: PropTypes.func,
+  placeholder: PropTypes.string,
   styles: PropTypes.object,
   value: PropTypes.string
 }

--- a/Field/PinCode/styles.scss
+++ b/Field/PinCode/styles.scss
@@ -39,6 +39,14 @@
     box-shadow: 0 0 ($grid * .8) map-get($colors, blue-shadow);
     outline: none;
     z-index: 20;
+
+    &::-webkit-input-placeholder {
+      opacity: 0;
+    }
+
+    &:-ms-input-placeholder {
+      opacity: 0;
+    }
   }
 
   &.error {

--- a/Field/PinCode/styles.scss
+++ b/Field/PinCode/styles.scss
@@ -40,4 +40,18 @@
     outline: none;
     z-index: 20;
   }
+
+  &.error {
+    background-color: map-get($colors, error-background);
+    border-color: map-get($colors, error-border);
+
+    &:hover {
+      border-color: map-get($colors, error-hover);
+    }
+
+    &:focus {
+      border-color: map-get($colors, error);
+      box-shadow: 0 0 ($grid * .8) map-get($colors, error-shadow);
+    }
+  }
 }

--- a/Field/PinCode/styles.scss
+++ b/Field/PinCode/styles.scss
@@ -14,20 +14,19 @@
   width: 100%;
 
   &::-webkit-input-placeholder {
-    // This should be the same color and font weight as .field__label.
-    bottom: ($grid * .6);
-    color: map-get($colors, grey-text);
-    font-size: ($grid * 4);
-    font-weight: 400;
+    @include typography(map-get($font-sizes, segmented-field-placeholder), regular);
+
+    bottom: ($grid * 1);
+    color: map-get($colors, grey-icon);
+    opacity: 1;
     position: relative;
   }
 
   &:-ms-input-placeholder {
-    // This should be the same color and font weight as .field__label.
-    bottom: ($grid * .6);
-    color: map-get($colors, grey-text);
-    font-size: ($grid * 4);
-    font-weight: 400;
+    @include typography(map-get($font-sizes, segmented-field-placeholder), regular);
+
+    bottom: ($grid * 1);
+    color: map-get($colors, grey-icon);
     position: relative;
   }
 

--- a/Field/example.jsx
+++ b/Field/example.jsx
@@ -195,10 +195,13 @@ import Fieldset from '@klarna/ui/Fieldset'`,
       type: LIVE,
 
       examples: {
-        Regular: <FieldVariation.PinCode
-          onChange={(value) => console.log(value)}
-          defaultValue='3134'
-        />,
+        Regular: (
+          <FieldVariation.PinCode
+            onChange={(value) => console.log(value)}
+            defaultValue='3134'
+            placeholder='Enter the value'
+          />
+        ),
 
         Controlled: <FieldVariation.PinCode
           onChange={(value) => console.log(value)}
@@ -213,6 +216,7 @@ import Fieldset from '@klarna/ui/Fieldset'`,
             inputColor: 'orange'
           }}
           defaultValue='1337'
+          placeholder='Enter the value'
         />
       }
     }

--- a/Field/example.jsx
+++ b/Field/example.jsx
@@ -203,21 +203,34 @@ import Fieldset from '@klarna/ui/Fieldset'`,
           />
         ),
 
-        Controlled: <FieldVariation.PinCode
-          onChange={(value) => console.log(value)}
-          value='312'
-        />,
+        Controlled: (
+          <FieldVariation.PinCode
+            onChange={(value) => console.log(value)}
+            value='312'
+          />
+        ),
 
-        Customized: <FieldVariation.PinCode
-          customize={{
-            borderColor: 'red',
-            borderColorSelected: 'purple',
-            borderRadius: '10px',
-            inputColor: 'orange'
-          }}
-          defaultValue='1337'
-          placeholder='Enter the value'
-        />
+        Error: (
+          <FieldVariation.PinCode
+            error
+            onChange={(value) => console.log(value)}
+            defaultValue='3134'
+            placeholder='Enter the value'
+          />
+        ),
+
+        Customized: (
+          <FieldVariation.PinCode
+            customize={{
+              borderColor: 'red',
+              borderColorSelected: 'purple',
+              borderRadius: '10px',
+              inputColor: 'orange'
+            }}
+            defaultValue='1337'
+            placeholder='Enter the value'
+          />
+        )
       }
     }
   ]

--- a/css/settings.scss
+++ b/css/settings.scss
@@ -106,7 +106,8 @@ $font-sizes: (
   title-secondary-desktop: ($grid * 3),
   title-secondary-mobile: ($grid * 3),
   subtitle: ($grid * 2.4),
-  segmented-field: ($grid * 5.2)
+  segmented-field: ($grid * 5.2),
+  segmented-field-placeholder: ($grid * 2.8)
 );
 
 // ================================================================

--- a/templates/CodePrompt/index.jsx
+++ b/templates/CodePrompt/index.jsx
@@ -56,6 +56,7 @@ function CodePrompt ({
       ) && onChange(e)}
       value={value}
       placeholder={label}
+      error={!!error}
     />
 
     {error && <div className={classNames(classes.error)}>


### PR DESCRIPTION
## Placeholder styles

![screen shot 2016-11-08 at 11 11 09](https://cloud.githubusercontent.com/assets/381614/20095058/28c23260-a5a4-11e6-8f8c-967eaefe799c.png)
![screen shot 2016-11-08 at 11 11 19](https://cloud.githubusercontent.com/assets/381614/20095059/28dc81ce-a5a4-11e6-80ba-28a9f77248af.png)

## Error style

![screen shot 2016-11-08 at 11 19 01](https://cloud.githubusercontent.com/assets/381614/20095290/3c5488ea-a5a5-11e6-85f9-9d42880d53ff.png)
![screen shot 2016-11-08 at 11 19 05](https://cloud.githubusercontent.com/assets/381614/20095291/3c54d1a6-a5a5-11e6-9aec-38d8b7941387.png)

## Propagate error passed to CodePrompt

![screen shot 2016-11-08 at 11 21 00](https://cloud.githubusercontent.com/assets/381614/20095363/7cc98466-a5a5-11e6-9ed3-c89777ac8c99.png)
