### PR TITLE
Add support for error message in the Centered chrome component

### DIFF
--- a/templates/CodePrompt/index.jsx
+++ b/templates/CodePrompt/index.jsx
@@ -61,13 +61,13 @@ function CodePrompt ({
     />
 
     {error && <div className={classNames(classes.error)}>
-      <Cross
-        className={classNames(classes.errorIcon)}
-        color='error'
-      />
       <Paragraph.Primary
         className={classNames(classes.errorParagraph)}
         color='error'>
+        <Cross
+          className={classNames(classes.errorIcon)}
+          color='error'
+        />
         {error}
       </Paragraph.Primary>
     </div>}

--- a/templates/CodePrompt/styles.scss
+++ b/templates/CodePrompt/styles.scss
@@ -10,6 +10,10 @@
   }
 }
 
+.code-prompt__error {
+  margin-top: ($grid * -.6);
+}
+
 .code-prompt__error__icon {
   display: inline-block;
   margin-right: ($grid * 1);

--- a/templates/chromes/Centered/index.jsx
+++ b/templates/chromes/Centered/index.jsx
@@ -68,13 +68,13 @@ export default function Centered ({
     </Paragraph.Primary>}
 
     {error && <div className={classNames(classes.error)}>
-      <Cross
-        className={classNames(classes.errorIcon)}
-        color='error'
-      />
       <Paragraph.Primary
         className={classNames(classes.errorParagraph)}
         color='error'>
+        <Cross
+          className={classNames(classes.errorIcon)}
+          color='error'
+        />
         {error}
       </Paragraph.Primary>
     </div>}

--- a/templates/chromes/Centered/index.jsx
+++ b/templates/chromes/Centered/index.jsx
@@ -4,12 +4,16 @@ import * as Dialog from '../../../Dialog'
 import * as Button from '../../../Button'
 import * as Paragraph from '../../../Paragraph'
 import * as Title from '../../../Title'
+import Cross from '../../../icons/Cross'
 import Link from '../../../Link'
 import defaultStyles from './styles.scss'
 
 const baseClass = 'chrome--centered'
 
 const classes = {
+  error: `${baseClass}__error`,
+  errorIcon: `${baseClass}__error__icon`,
+  errorParagraph: `${baseClass}__error__paragraph`,
   title: `${baseClass}__title`,
   paragraphPrimary: `${baseClass}__paragraph--primary`,
   buttonAccept: `${baseClass}__button--accept`,
@@ -20,6 +24,7 @@ const classes = {
 export default function Centered ({
   className,
   children,
+  error,
   labels,
   illustration,
   loading,
@@ -61,6 +66,18 @@ export default function Centered ({
         {labels.cancel}
       </Link>
     </Paragraph.Primary>}
+
+    {error && <div className={classNames(classes.error)}>
+      <Cross
+        className={classNames(classes.errorIcon)}
+        color='error'
+      />
+      <Paragraph.Primary
+        className={classNames(classes.errorParagraph)}
+        color='error'>
+        {error}
+      </Paragraph.Primary>
+    </div>}
 
     {labels.legal && <Paragraph.Legal className={classNames(classes.legal)}>
       {labels.legal}

--- a/templates/chromes/Centered/styles.scss
+++ b/templates/chromes/Centered/styles.scss
@@ -37,6 +37,10 @@
   padding-top: ($grid * 6.2);
 }
 
+.chrome--centered__button--accept + .chrome--centered__error {
+  padding-top: ($grid * 1.4);
+}
+
 .chrome--centered__error__icon {
   display: inline-block;
   margin-right: ($grid * 1);
@@ -46,8 +50,4 @@
 
 .chrome--centered__error__paragraph {
   display: inline-block;
-}
-
-.chrome--centered__error + .chrome--centered__message {
-  margin-top: ($grid * 3);
 }

--- a/templates/chromes/Centered/styles.scss
+++ b/templates/chromes/Centered/styles.scss
@@ -36,3 +36,18 @@
 .chrome--centered__paragraph--legal {
   padding-top: ($grid * 6.2);
 }
+
+.chrome--centered__error__icon {
+  display: inline-block;
+  margin-right: ($grid * 1);
+  position: relative;
+  top: ($grid * 1);
+}
+
+.chrome--centered__error__paragraph {
+  display: inline-block;
+}
+
+.chrome--centered__error + .chrome--centered__message {
+  margin-top: ($grid * 3);
+}

--- a/templates/examples/Informative.jsx
+++ b/templates/examples/Informative.jsx
@@ -42,6 +42,31 @@ export default {
           </Wrapper>
         },
 
+        'With error': {
+          inline: <Landing
+            illustration={<DemoIcon />}
+            labels={{
+              title: 'Welcome to the site',
+              summary: 'Chia williamsburg subway tile vaporware, live-edge kinfolk cardigan prism deep v retro seitan.',
+              accept: 'Continue'
+            }}
+            onAccept={() => console.log('accept')}
+            error='It’s wingardium leviosa'
+          />,
+
+          wrapper: <Wrapper>
+            <Landing
+              illustration={<DemoIcon />}
+              labels={{
+                title: 'Welcome to the site',
+                summary: 'Chia williamsburg subway tile vaporware, live-edge kinfolk cardigan prism deep v retro seitan.',
+                accept: 'Continue'
+              }}
+              onAccept={() => console.log('accept')}
+            />
+          </Wrapper>
+        },
+
         'With legal copy': {
           inline: <Landing
             illustration={<DemoIcon />}


### PR DESCRIPTION
Clicking the button may mean performing some async action, that may fail. We need to show this failure for the authentication service.

I just plain out copy-pasted the implementation of CodePrompt for this. Looks like this:

<img width="993" alt="screen shot 2016-11-09 at 15 52 48" src="https://cloud.githubusercontent.com/assets/569742/20142372/b820a07c-a694-11e6-8fc7-c0d1dec77182.png">

One thing that I noticed in the CodePrompt, is that the text doesn't wrap the way it was intended:

Current implementation:

<img width="395" alt="no-bueno" src="https://cloud.githubusercontent.com/assets/569742/20142510/4f1e64fa-a695-11e6-94c0-e94fb35dd11f.png">

vs the design:

<img width="428" alt="bueno" src="https://cloud.githubusercontent.com/assets/569742/20142511/4f1fb472-a695-11e6-8c30-4939bfdda161.png">

Any ideas on how we could do this? I'll start playing around with it, but holla at me if you have a quick fix.

