### PR TITLE
Support code-prompt loading state without text

### DIFF
--- a/templates/CodePrompt/index.jsx
+++ b/templates/CodePrompt/index.jsx
@@ -43,6 +43,8 @@ function CodePrompt ({
   ...props
 }) {
   const classNames = classNamesBind.bind({...defaultStyles, ...styles})
+  const loadingText = loading
+  loading = loading || loadingText === ''
 
   return <Centered
     labels={{summary, title}}
@@ -77,10 +79,12 @@ function CodePrompt ({
         className={classNames(classes.loadingLoader)}
         size='small'
       />
-      <Paragraph.Secondary
-        className={classNames(classes.loadingParagraph)}>
-        {loading}
-      </Paragraph.Secondary>
+      {loadingText !== '' && (
+        <Paragraph.Secondary
+          className={classNames(classes.loadingParagraph)}>
+          {loadingText}
+        </Paragraph.Secondary>
+      )}
     </div>}
 
     {message && <Paragraph.Secondary

--- a/templates/CodePrompt/styles.scss
+++ b/templates/CodePrompt/styles.scss
@@ -31,11 +31,11 @@
 
 .code-prompt__loading__loader {
   display: inline-block;
-  margin-right: ($grid * 1.8);
   position: relative;
   top: ($grid * .4);
 }
 
 .code-prompt__loading__paragraph {
   display: inline-block;
+  margin-left: ($grid * 1.8);
 }

--- a/templates/examples/Prompts.jsx
+++ b/templates/examples/Prompts.jsx
@@ -170,6 +170,17 @@ export default {
             onChange={(e) => console.log(e.target.value)}
             loading='Spell in progress'
           />
+        },
+
+        'Loading without loading-text': {
+          inline: <CodePrompt
+            defaultValue='123'
+            label='The numbers'
+            title='Enter the magic numbers'
+            summary='You know them. You’ve seen Lost too.'
+            onChange={(e) => console.log(e.target.value)}
+            loading=''
+          />
         }
       }
     }


### PR DESCRIPTION
We need to support the loading state of the CodePrompt template, but without any text next to the spinner. As a POC we sent in a space character `' '` which kind of worked, but it will still offset the spinner by 9px since the styles assume that there will be text.

I thought of 2 options to support this, and I don't have a very strong opinion, I just went with nr 2:

1. Pass `loading=true` to indicate that you want the loading state, but there's no text-string to show
2. Pass `loading=''` to indicate that you want the loading state, but the text is the empty string, aka there's no text-string to show

If there's another, better alternative, or if you like another option better, we can go with that.

![code-promp-loading](https://cloud.githubusercontent.com/assets/569742/20178762/fbf64d10-a752-11e6-87d4-679472f70ebf.gif)
