### PR TITLE
Trigger blur when PinCode field is disabled

### DIFF
--- a/Field/PinCode/index.jsx
+++ b/Field/PinCode/index.jsx
@@ -18,6 +18,12 @@ class PinCode extends PureComponent {
     }
   }
 
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.disabled && !this.props.disabled && this.state.focus && this._input) {
+      this._input.blur()
+    }
+  }
+
   render () {
     const {
       className,
@@ -55,6 +61,7 @@ class PinCode extends PureComponent {
       onMouseEnter={() => this.setState({hover: true})}
       onMouseLeave={() => this.setState({hover: false})}
       maxLength={length}
+      ref={(elem) => this._input = elem}
       style={inputStyle}
       type='tel'
       value={value}

--- a/Field/PinCode/index.jsx
+++ b/Field/PinCode/index.jsx
@@ -19,9 +19,7 @@ class PinCode extends PureComponent {
   }
 
   componentWillReceiveProps (nextProps) {
-    if (nextProps.disabled && !this.props.disabled && this.state.focus && this._input) {
-      this._input.blur()
-    }
+    blurOnDisable(this._input)(nextProps, this.props, this.state)
   }
 
   render () {
@@ -112,3 +110,17 @@ export default compose(
   })),
   overridable(defaultStyles)
 )(PinCode)
+
+function blurOnDisable (input) {
+  return (nextProps, currentProps, currentState) => {
+    const inputExists = !!input
+    const isFocused = currentState.focus
+    const aboutToBeDisabled = nextProps.disabled && !currentProps.disabled
+
+    if (inputExists && isFocused && aboutToBeDisabled) {
+      // Some devices (iOS 10 in particular) will not hide the keyboard automatically
+      // when the field is disabled, so a programmatic blur is required.
+      input.blur()
+    }
+  }
+}

--- a/Field/PinCode/index.jsx
+++ b/Field/PinCode/index.jsx
@@ -61,7 +61,7 @@ class PinCode extends PureComponent {
       onMouseEnter={() => this.setState({hover: true})}
       onMouseLeave={() => this.setState({hover: false})}
       maxLength={length}
-      ref={(elem) => this._input = elem}
+      ref={(elem) => { this._input = elem }}
       style={inputStyle}
       type='tel'
       value={value}


### PR DESCRIPTION
Some devices (iOS 10) will leave the keyboard open if the field is disabled while it has focus. Since `PinCode` is used as an auto-submitting field, this will always happen.

I had another version where the logic was a more verbose and explanatory, like:

```jsx
    componentWillReceiveProps (nextProps) {
      const inputExists = !!this._input
      const hasFocus = this.state.focus
      const willBeDisabled = nextProps.disabled && !this.props.disabled

      if (inputExists && hasFocus && willBeDisabled) {
        this._input.blur()
      }
    }
```

Not sure if it adds that much though. The code as it stands now, along with the git log message, should be enough to explain what's going on. I think.