### PR TITLE
Ensure PinCode input loses focus when it is disabled

### DIFF
--- a/Field/PinCode/index.jsx
+++ b/Field/PinCode/index.jsx
@@ -18,6 +18,12 @@ class PinCode extends PureComponent {
     }
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.disabled && !this.props.disabled && this.state.focus) {
+      this._input.blur()
+    }
+  }
+
   render () {
     const {
       className,
@@ -48,6 +54,7 @@ class PinCode extends PureComponent {
     } : style
 
     return <input
+      ref={(elm) => this._input = elm}
       className={classNames(baseClass, {error}, className)}
       onBlur={() => this.setState({focus: false})}
       onChange={onChange}


### PR DESCRIPTION
This is to make sure the keyboard on iOS gets hidden when to input field
gets disabled.