### PR TITLE
Separate error state from error message in CodePrompt

### DIFF
--- a/templates/CodePrompt/index.jsx
+++ b/templates/CodePrompt/index.jsx
@@ -46,6 +46,7 @@ function CodePrompt ({
   const classNames = classNamesBind.bind({...defaultStyles, ...styles})
   const loadingText = loading
   loading = loading || loadingText === ''
+  error = errorMessage && error == null ? true : error
 
   return <Centered
     labels={{summary, title}}

--- a/templates/CodePrompt/index.jsx
+++ b/templates/CodePrompt/index.jsx
@@ -32,6 +32,7 @@ const isDigit = (x) => [
 function CodePrompt ({
   autoFocus,
   error,
+  errorMessage,
   label,
   loading,
   message,
@@ -58,11 +59,11 @@ function CodePrompt ({
       ) && onChange(e)}
       value={value}
       placeholder={label}
-      error={!!error}
+      error={error}
       disabled={loading}
     />
 
-    {error && <div className={classNames(classes.error)}>
+    {errorMessage && <div className={classNames(classes.error)}>
       <Paragraph.Primary
         className={classNames(classes.errorParagraph)}
         color='error'>
@@ -70,7 +71,7 @@ function CodePrompt ({
           className={classNames(classes.errorIcon)}
           color='error'
         />
-        {error}
+        {errorMessage}
       </Paragraph.Primary>
     </div>}
 

--- a/templates/examples/Prompts.jsx
+++ b/templates/examples/Prompts.jsx
@@ -164,14 +164,27 @@ export default {
           />
         },
 
-        'With error': {
+        'With error and message': {
           inline: <CodePrompt
             defaultValue='123'
             label='The numbers'
             title='Enter the magic numbers'
             summary='You know them. You’ve seen Lost too.'
             onChange={(e) => console.log(e.target.value)}
-            error='It’s wingardium leviosa'
+            error
+            errorMessage='It’s wingardium leviosa'
+            message={<span><Link href='#'>Try spell again</Link></span>}
+          />
+        },
+
+        'With error-message only': {
+          inline: <CodePrompt
+            defaultValue='123'
+            label='The numbers'
+            title='Enter the magic numbers'
+            summary='You know them. You’ve seen Lost too.'
+            onChange={(e) => console.log(e.target.value)}
+            errorMessage='It’s wingardium leviosa'
             message={<span><Link href='#'>Try spell again</Link></span>}
           />
         },

--- a/templates/examples/Prompts.jsx
+++ b/templates/examples/Prompts.jsx
@@ -171,7 +171,6 @@ export default {
             title='Enter the magic numbers'
             summary='You know them. You’ve seen Lost too.'
             onChange={(e) => console.log(e.target.value)}
-            error
             errorMessage='It’s wingardium leviosa'
             message={<span><Link href='#'>Try spell again</Link></span>}
           />
@@ -184,6 +183,7 @@ export default {
             title='Enter the magic numbers'
             summary='You know them. You’ve seen Lost too.'
             onChange={(e) => console.log(e.target.value)}
+            error={false}
             errorMessage='It’s wingardium leviosa'
             message={<span><Link href='#'>Try spell again</Link></span>}
           />


### PR DESCRIPTION
We have a use case in the Authentication UI to show an error message, but the input should not be in the error state. This was our take on how to accomplish that.