### PR TITLE
Fix the isDigit function

### DIFF
--- a/templates/CodePrompt/index.jsx
+++ b/templates/CodePrompt/index.jsx
@@ -22,12 +22,11 @@ const classes = {
   message: `${baseClass}__message`
 }
 
-const any = (a, b) => a || b
 const all = (a, b) => a && b
 
 const isDigit = (x) => [
   '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'
-].reduce(any, false)
+].indexOf(x) >= 0
 
 function CodePrompt ({
   autoFocus,


### PR DESCRIPTION
It wasn't actually using the variable `x`, it would short-circuit to `false || '0'` and return true every time.

@xaviervia WHERE'S YOUR IVORY TOWER NOW? :)