### PR TITLE
Track bundle size changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_script:
 - npm install
 script:
 - npm test
+- curl -O https://raw.githubusercontent.com/danvk/travis-weigh-in/master/weigh_in.py && python weigh_in.py index-built.js
 deploy:
   provider: npm
   email: ui-admin.e@klarna.com


### PR DESCRIPTION
As a first step for #181, it should be simple enough to at least show how a PR is affecting the bundle size.

Given that Travis executes the prepublish step and builds the distributed version, this should work.

Hopefully we'll see something like this when this PR is built, though there's no built-index.js to compare to, so we'll just see the absolute size, I think. But once it's in place, it'll compare it to the target branch and show you the relative difference.

![Example](https://cloud.githubusercontent.com/assets/98301/10703019/161a9d40-799b-11e5-9798-8ebbab465d02.png)