### PR TITLE
No double dependency install on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
 - '6'
-before_script:
-- npm install
 script:
 - npm test
 deploy:


### PR DESCRIPTION
Since Travis uses yarn by default, it's already installing dependencies. No need to do it twice