### PR TITLE
Add handler for orientationchange to installments component

### DIFF
--- a/Installments/index.jsx
+++ b/Installments/index.jsx
@@ -93,12 +93,15 @@ const Installments = React.createClass({
     }
 
     this.debouncedResizeHandler = debounce(() => this.onResize())
-    window.addEventListener('resize', this.debouncedResizeHandler)
+    window.addEventListener('resize', this.debouncedResizeHandler, false)
+    window.addEventListener('orientationchange', this.onOrientationChange, false)
+
     this.setHighlightPosition(calculateHighlightPosition(this.getSelectedLabel()))
   },
 
   componentWillUnmount () {
     window.removeEventListener('resize', this.debouncedResizeHandler)
+    window.removeEventListener('orientationchange', this.onOrientationChange)
   },
 
   componentWillReceiveProps (props) {
@@ -129,6 +132,15 @@ const Installments = React.createClass({
 
   onResize () {
     this.setHighlightPosition(calculateHighlightPosition(this.getSelectedLabel()))
+  },
+
+  onOrientationChange () {
+    this.setHighlightPosition({
+      width: 0,
+      height: 0,
+      left: 0,
+      top: 0
+    })
   },
 
   getSelectedLabel (key) {

--- a/Installments/index.jsx
+++ b/Installments/index.jsx
@@ -135,12 +135,7 @@ const Installments = React.createClass({
   },
 
   onOrientationChange () {
-    this.setHighlightPosition({
-      width: 0,
-      height: 0,
-      left: 0,
-      top: 0
-    })
+    this.resetHighlightPosition()
   },
 
   getSelectedLabel (key) {
@@ -156,6 +151,15 @@ const Installments = React.createClass({
           ...position
         }
       }
+    })
+  },
+
+  resetHighlightPosition () {
+    this.setHighlightPosition({
+      width: 0,
+      height: 0,
+      left: 0,
+      top: 0
     })
   },
 


### PR DESCRIPTION
If you select the 4th payment option on iphone 6 in landscape mode and then rotate the phone, the component will end up in a state like on the following image

![img_5436](https://cloud.githubusercontent.com/assets/2915276/20748036/e8e0c404-b6ec-11e6-9954-b8fc78ef5237.PNG)

The position of the highlight element is not recalculated.

This PR is adding handler on `orientationchange` which updates the position to the highlight element to 0, 0 and that will trigger recalculation.