### PR TITLE
[Title: Primary Secondary]Use the correct customization property for text color

### DIFF
--- a/Paragraph/Primary/index.jsx
+++ b/Paragraph/Primary/index.jsx
@@ -58,7 +58,7 @@ export default compose(
   themeable(isThemeable((customizations, props) => ({
     style: {
       ...props.style,
-      color: customizations.color_header
+      color: customizations.color_text
     }
   }))),
   overridable(defaultStyles)

--- a/Paragraph/Secondary/index.jsx
+++ b/Paragraph/Secondary/index.jsx
@@ -58,7 +58,7 @@ export default compose(
   themeable(isThemeable((customizations, props) => ({
     style: {
       ...props.style,
-      color: customizations.color_header
+      color: customizations.color_text_secondary
     }
   }))),
   overridable(defaultStyles)


### PR DESCRIPTION
When implementing #213 accidentally updated the customisation property controlling the color of text for Primary and Secondary Title. Reverting to the proper one.

@xaviervia, @Nevon 