### PR TITLE
Fix to ensure custom styled is applied on Text components when conditionally themed

### DIFF
--- a/Text/isThemeable.js
+++ b/Text/isThemeable.js
@@ -1,7 +1,7 @@
 const UNTHEMED_STATES = ['error', 'warning']
 
 const isThemeable = (adapter) => (customizations, props) => {
-  return UNTHEMED_STATES.includes(props.color) ? () => {} : adapter
+  return UNTHEMED_STATES.includes(props.color) ? {} : adapter(customizations, props)
 }
 
 export default isThemeable

--- a/Theme/example.jsx
+++ b/Theme/example.jsx
@@ -250,8 +250,16 @@ import * as List from '@klarna/ui/List'`,
             Primary Paragraph, primary design
           </Paragraph.Primary>
 
+          <Paragraph.Primary margins color='error'>
+            An error text should reject custom style in favor of the initial style.
+          </Paragraph.Primary>
+
           <Paragraph.Secondary margins>
             Paragraph, secondary design
+          </Paragraph.Secondary>
+
+          <Paragraph.Secondary margins color='warning'>
+            An error text should reject custom style in favor of the initial style.
           </Paragraph.Secondary>
 
           <Paragraph.Legal margins>


### PR DESCRIPTION
`isThemeable` should return the actual themed or not style.

The actual `adapter` function was never called, so merchant styling was never applied.
This should fix it :) @xaviervia @Nevon 