### PR TITLE
Hide and show the highlight element on orientation change

### DIFF
--- a/Installments/index.jsx
+++ b/Installments/index.jsx
@@ -163,7 +163,7 @@ const Installments = React.createClass({
   },
 
   resetHighlightPosition () {
-    this.refs.highlight.style.display = 'none';
+    this.refs.highlight.style.display = 'none'
     this.setHighlightPosition({
       width: 0,
       height: 0,
@@ -172,7 +172,7 @@ const Installments = React.createClass({
     })
 
     setTimeout(() => {
-      this.refs.highlight.style.display = 'block';
+      this.refs.highlight.style.display = 'block'
     })
   },
 
@@ -199,7 +199,7 @@ const Installments = React.createClass({
     const currentWidth = window.getComputedStyle(this.refs.root).width
     const layout = this.getLayoutType(currentWidth)
 
-    if (layout != this.state.currentLayout) {
+    if (layout !== this.state.currentLayout) {
       this.setCurrentLayout(layout)
       return true
     }

--- a/Installments/index.jsx
+++ b/Installments/index.jsx
@@ -8,6 +8,7 @@ import compose from '../lib/compose'
 
 const baseClass = 'installments'
 const TRANSITION_DURATION = 500
+const MOBILE_MAX_WIDTH = 569
 
 const classes = {
   input: `${baseClass}__input`,
@@ -72,6 +73,7 @@ const Installments = React.createClass({
     return {
       hover: undefined,
       previouslySelected: undefined,
+      currentLayout: undefined,
       highlight: {
         position: {
           width: undefined,
@@ -131,11 +133,17 @@ const Installments = React.createClass({
   },
 
   onResize () {
-    this.setHighlightPosition(calculateHighlightPosition(this.getSelectedLabel()))
+    if (this.state.currentLayout && this.hasLayoutChanged()) {
+      this.resetHighlightPosition()
+    } else {
+      this.setHighlightPosition(calculateHighlightPosition(this.getSelectedLabel()))
+    }
   },
 
   onOrientationChange () {
-    this.resetHighlightPosition()
+    if (this.hasLayoutChanged()) {
+      this.resetHighlightPosition()
+    }
   },
 
   getSelectedLabel (key) {
@@ -155,11 +163,16 @@ const Installments = React.createClass({
   },
 
   resetHighlightPosition () {
+    this.refs.highlight.style.display = 'none';
     this.setHighlightPosition({
       width: 0,
       height: 0,
       left: 0,
       top: 0
+    })
+
+    setTimeout(() => {
+      this.refs.highlight.style.display = 'block';
     })
   },
 
@@ -170,6 +183,28 @@ const Installments = React.createClass({
         transitions: enabled
       }
     })
+  },
+
+  setCurrentLayout (layout) {
+    this.setState({
+      currentLayout: layout
+    })
+  },
+
+  getLayoutType (width) {
+    return parseInt(width, 10) > MOBILE_MAX_WIDTH ? 'wide' : 'narrow'
+  },
+
+  hasLayoutChanged () {
+    const currentWidth = window.getComputedStyle(this.refs.root).width
+    const layout = this.getLayoutType(currentWidth)
+
+    if (layout != this.state.currentLayout) {
+      this.setCurrentLayout(layout)
+      return true
+    }
+
+    return false
   },
 
   render () {
@@ -222,6 +257,7 @@ const Installments = React.createClass({
     }
 
     return (<div
+      ref='root'
       className={classNames(baseClass, className)}
       style={{
         ...dynamicStyles,
@@ -272,7 +308,9 @@ const Installments = React.createClass({
           </label>
         })}
       </div>
-      <span className={classNames(
+      <span
+        ref='highlight'
+        className={classNames(
         classes.cellHighlight,
         { 'has-position': this.state.highlight.transitions }
       )} style={{


### PR DESCRIPTION
Depending on the position of the highlight element it can brake the layout when the orientation is changed (from landscape to portail on iphone6).

To fix this, we will hide the highlight element, then show it and position it in the next thick. This will allow to the browser to update the layout properly and we will position the element in the resulting layout.

Browsers trigger `orientationchange` whenever the height becomes bigger than the width and vice versa. This PR prevent triggering of the `orientationchange` handler on resize of the browser window on desktop. In that case the media queries should handle the layout change.