### PR TITLE
Update iconic lists

### DIFF
--- a/List/Iconic/index.jsx
+++ b/List/Iconic/index.jsx
@@ -25,17 +25,20 @@ Wrapper.displayName = 'List.Iconic.Wrapper'
 export function Item ({className, icon, children, styles, ...props}) {
   const classNames = classNamesBind.bind({...defaultStyles, ...styles})
 
-  return <li className={classNames(classes.item, className)} {...props}>
-    <div className={classNames(classes.itemIcon)}>
-      {icon}
-    </div>
-
-    <div className={classNames(classes.content)}>
-      <Paragraph.Secondary>
-        {children}
-      </Paragraph.Secondary>
-    </div>
-  </li>
+  return <div className={classNames(classes.item)} {...props}>
+    <tbody>
+      <tr>
+        <td className={classNames(classes.itemIcon)}>
+          {icon}
+        </td>
+        <td>
+          <Paragraph.Secondary>
+            {children}
+          </Paragraph.Secondary>
+        </td>
+      </tr>
+    </tbody>
+  </div>
 }
 
 Item.displayName = 'List.Iconic.Item'

--- a/List/Iconic/styles.scss
+++ b/List/Iconic/styles.scss
@@ -2,13 +2,13 @@
 @import '../../css/mixins/index';
 
 .list--iconic--wrapper {
-  list-style: none;
   margin: 0;
   padding: 0;
   width: 100%;
 }
 
 .list--iconic--item {
+  display: table;
   margin: 0;
   overflow: auto;
   padding: 0;
@@ -19,18 +19,11 @@
 }
 
 .list--iconic--item__icon {
-  float: left;
   height: ($grid * 12);
-  margin-right: ($grid * 4);
   width: ($grid * 12);
 
   svg {
     display: block;
+    padding-right: ($grid * 4);
   }
-}
-
-.list--iconic--item__content {
-  float: left;
-  margin-top: ($grid * -2);
-  width: calc(100% - #{($grid * 16)});
 }


### PR DESCRIPTION
Alignment of elements with smaller text than image are fixed now.

![screen shot 2016-12-09 at 15 59 18](https://cloud.githubusercontent.com/assets/381614/21053152/76cc4d28-be28-11e6-9146-30ffb49deff4.png)
