### PR TITLE
Make the Radio option header the only clickable part

### DIFF
--- a/Radio/index.jsx
+++ b/Radio/index.jsx
@@ -132,8 +132,7 @@ const Radio = React.createClass({
               value={key}
               disabled={isDisabled}
             />,
-            <label
-              htmlFor={`${name}-${key}`}
+            <div
               className={classNames(
                 classes.option,
                 {
@@ -143,7 +142,7 @@ const Radio = React.createClass({
                 }
               )}
               {...restOfProps}>
-              <div className={classNames(classes.optionHeader)}>
+              <label htmlFor={`${name}-${key}`} className={classNames(classes.optionHeader)}>
                 <div className={classNames(classes.optionHeaderInner)}>
                   {!singleOption && <div className={classNames(classes.optionLeft)}>
                     <div className={classNames(classes.optionWrapper)}>
@@ -177,7 +176,7 @@ const Radio = React.createClass({
                     {aside}
                   </div>}
                 </div>
-              </div>
+              </label>
 
               {content && <Collapsible
                 collapsed={isDisabled || !singleOption && key !== value}>
@@ -185,7 +184,7 @@ const Radio = React.createClass({
                   {content}
                 </div>
               </Collapsible>}
-            </label>
+            </div>
           ]
         })}
       </div>

--- a/Radio/styles.scss
+++ b/Radio/styles.scss
@@ -33,11 +33,9 @@
 
 .radio__option {
   border-bottom: ($grid * .2) solid map-get($colors, grey-selector-lines);
-  cursor: pointer;
   display: block;
   margin-top: ($grid * -.2);
   overflow: hidden;
-  padding-top: ($grid * 4);
   position: relative;
   user-select: none;
 
@@ -56,7 +54,6 @@
   &.is-disabled {
     background: #fafafa;
     color: map-get($colors, grey-lines);
-    cursor: default;
     pointer-events: none;
   }
 
@@ -68,10 +65,12 @@
 }
 
 .radio__option__header {
+  cursor: pointer;
   display: table;
-  margin-bottom: ($grid * 4);
+  padding-bottom: ($grid * 4);
   padding-left: ($grid * 4);
   padding-right: ($grid * 4);
+  padding-top: ($grid * 4);
   width: calc(100% - #{$grid * 8});
 }
 


### PR DESCRIPTION
This fixes an issue in IE10 that prevents interactive content inside the Radio to be changed (such as selection element).