### PR TITLE
Use opacity for disabled radio text

### DIFF
--- a/Radio/styles.scss
+++ b/Radio/styles.scss
@@ -71,10 +71,6 @@
   padding-right: ($grid * 4);
   padding-top: ($grid * 4);
   width: calc(100% - #{$grid * 8});
-  
-  &.is-disabled {
-    opacity: $disabled-selector;
-  }
 }
 
 .radio__option__inner {
@@ -167,6 +163,10 @@
 
   @include respond-to-wide {
     @include typography(map-get($font-sizes, big-body-desktop), semi-bold);
+  }
+  
+  &.is-disabled {
+    opacity: $disabled-selector;
   }
 }
 

--- a/Radio/styles.scss
+++ b/Radio/styles.scss
@@ -96,7 +96,7 @@
   padding-left: ($grid * 3);
   text-align: right;
   vertical-align: top;
-  
+
   .is-disabled & {
     opacity: $disabled-selector;
   }
@@ -164,8 +164,8 @@
   @include respond-to-wide {
     @include typography(map-get($font-sizes, big-body-desktop), semi-bold);
   }
-  
-  &.is-disabled {
+
+  .is-disabled & {
     opacity: $disabled-selector;
   }
 }

--- a/Radio/styles.scss
+++ b/Radio/styles.scss
@@ -53,7 +53,6 @@
 
   &.is-disabled {
     background: #fafafa;
-    opacity: $disabled-selector;
     pointer-events: none;
   }
 
@@ -72,6 +71,10 @@
   padding-right: ($grid * 4);
   padding-top: ($grid * 4);
   width: calc(100% - #{$grid * 8});
+  
+  &.is-disabled {
+    opacity: $disabled-selector;
+  }
 }
 
 .radio__option__inner {

--- a/Radio/styles.scss
+++ b/Radio/styles.scss
@@ -53,7 +53,7 @@
 
   &.is-disabled {
     background: #fafafa;
-    color: map-get($colors, grey-lines);
+    opacity: .2;
     pointer-events: none;
   }
 

--- a/Radio/styles.scss
+++ b/Radio/styles.scss
@@ -53,7 +53,7 @@
 
   &.is-disabled {
     background: #fafafa;
-    opacity: .2;
+    opacity: $disabled-selector;
     pointer-events: none;
   }
 
@@ -99,7 +99,7 @@
   vertical-align: top;
   
   .is-disabled & {
-    opacity: $disabled-selector-logo;
+    opacity: $disabled-selector;
   }
 }
 
@@ -177,6 +177,6 @@
   }
 
   .is-disabled & {
-    color: map-get($colors, grey-lines);
+    opacity: $disabled-selector;
   }
 }

--- a/css/settings.scss
+++ b/css/settings.scss
@@ -121,4 +121,4 @@ $border-color-inner: map-get($colors, light-grey);
 // ================================================================
 //  Opacity
 // ================================================================
-$disabled-selector-logo: 0.2;
+$disabled-selector: 0.2;


### PR DESCRIPTION
We have an issue with merchant styling overwriting the text color of locked methods. We can output the same look by using opacity and this will make merchant styling work properly. 
Current Look:
<img width="661" alt="current_lock_wo-merch-styling" src="https://cloud.githubusercontent.com/assets/11426561/21155884/d6d4bff4-c141-11e6-9da9-0507aa21af66.png">

Look with Proposed Changes
<img width="660" alt="screen shot 2016-12-13 at 3 10 00 pm" src="https://cloud.githubusercontent.com/assets/11426561/21157117/4e20eed0-c146-11e6-8b2b-d5e1925b77d8.png">

Merchant Styling Look with Proposed Changes 
<img width="671" alt="proposed_lock-with-merchant-styling" src="https://cloud.githubusercontent.com/assets/11426561/21155964/205ea64e-c142-11e6-8039-8bc695d64dfb.png">


