### PR TITLE
Make sure displayName is set in IconButtons when overridable

### DIFF
--- a/IconButton/Back/index.jsx
+++ b/IconButton/Back/index.jsx
@@ -56,6 +56,6 @@ Back.propTypes = {
 
 export default compose(
   themeable(() => ({color: 'gray'})),
-  withDisplayName('Back'),
-  overridable(defaultStyles)
+  overridable(defaultStyles),
+  withDisplayName('Back')
 )(Back)

--- a/IconButton/Close/index.jsx
+++ b/IconButton/Close/index.jsx
@@ -56,6 +56,6 @@ Close.propTypes = {
 
 export default compose(
   themeable(() => ({color: 'gray'})),
-  withDisplayName('Close'),
-  overridable(defaultStyles)
+  overridable(defaultStyles),
+  withDisplayName('Close')
 )(Close)

--- a/IconButton/Hamburger/index.jsx
+++ b/IconButton/Hamburger/index.jsx
@@ -58,6 +58,6 @@ Hamburger.propTypes = {
 
 export default compose(
   themeable(() => ({color: 'gray'})),
-  withDisplayName('Hamburger'),
-  overridable(defaultStyles)
+  overridable(defaultStyles),
+  withDisplayName('Hamburger')
 )(Hamburger)

--- a/IconButton/Options/index.jsx
+++ b/IconButton/Options/index.jsx
@@ -56,6 +56,6 @@ Options.propTypes = {
 
 export default compose(
   themeable(() => ({color: 'gray'})),
-  withDisplayName('Options'),
-  overridable(defaultStyles)
+  overridable(defaultStyles),
+  withDisplayName('Options')
 )(Options)

--- a/IconButton/Search/index.jsx
+++ b/IconButton/Search/index.jsx
@@ -55,6 +55,6 @@ Search.propTypes = {
 
 export default compose(
   themeable(() => ({color: 'gray'})),
-  withDisplayName('Search'),
-  overridable(defaultStyles)
+  overridable(defaultStyles),
+  withDisplayName('Search')
 )(Search)


### PR DESCRIPTION
The issue was that the `withDisplayName` higher-order component was applied too late, after the `overridable` already picked up a wrong `displayName` for the IconButtons. This was causing style overrides not to apply.