### PR TITLE
Fix installments heighlight dimensions on android stock

### DIFF
--- a/Installments/Horizontal/styles.scss
+++ b/Installments/Horizontal/styles.scss
@@ -87,18 +87,22 @@ $highlightTransitionEasing: cubic-bezier(.31,.09,.24,1);
 .installments--horizontal__cell__highlight {
   border: ($grid * .4) solid map-get($colors, klarna-blue);
   border-radius: 5px;
+  bottom: -1px;
   box-sizing: border-box;
   cursor: pointer;
   display: block;
-  height: ($grid * 15);
   left: -1px;
   opacity: 0;
   pointer-events: none;
   position: absolute;
+  right: -1px;
   top: -1px;
   transition: opacity .4s ease;
-  width: calc(100% + 2px);
   z-index: 5;
+
+  @include respond-to-ie((9,10)) {
+    height: ($grid * 15);
+  }
 
   .is-selected & {
     opacity: 1;

--- a/Installments/Horizontal/styles.scss
+++ b/Installments/Horizontal/styles.scss
@@ -91,6 +91,7 @@ $highlightTransitionEasing: cubic-bezier(.31,.09,.24,1);
   box-sizing: border-box;
   cursor: pointer;
   display: block;
+  height: ($grid * 15);
   left: -1px;
   opacity: 0;
   pointer-events: none;
@@ -99,10 +100,6 @@ $highlightTransitionEasing: cubic-bezier(.31,.09,.24,1);
   top: -1px;
   transition: opacity .4s ease;
   z-index: 5;
-
-  @include respond-to-ie((9,10)) {
-    height: ($grid * 15);
-  }
 
   .is-selected & {
     opacity: 1;

--- a/Installments/Vertical/styles.scss
+++ b/Installments/Vertical/styles.scss
@@ -87,17 +87,17 @@ $highlightTransitionEasing: cubic-bezier(.31,.09,.24,1);
 .installments--vertical__cell__highlight {
   border: ($grid * .4) solid map-get($colors, klarna-blue);
   border-radius: 5px;
+  bottom: -1px;
   box-sizing: border-box;
   cursor: pointer;
   display: block;
-  height: calc(100% + 2px);
   left: -1px;
   opacity: 0;
   pointer-events: none;
   position: absolute;
+  right: -1px;
   top: -1px;
   transition: opacity .4s ease;
-  width: calc(100% + 2px);
   z-index: 5;
 
   .is-selected & {


### PR DESCRIPTION
The problem is that the highlight element on Android stock browser looked like a blue dot, like on the image below

![screen shot 2016-12-21 at 09 13 43](https://cloud.githubusercontent.com/assets/2915276/21381839/e629c20c-c75d-11e6-9431-64c7967aad89.png)

To fix it, instead of calculating the width and the height of the highlight element using `calc()`, which is not supported in old Android stock browser, we will use workaround by setting the `top`, `bottom`, `left`, `right` to `-1px`.
For the horizontal installments we have to set the `height` explicitly to fix it for IE9 and IE10.

With the solution above in Android stock the `2px` compensation for the border doesn't work only for the horizontal component. But it looks acceptable and the solution works pixel perfect in all other browsers (checked in IE9, IE10, IE11, Firefox, Safari, Chrome)

Here is how it looks on Android stock now:
![screenshot_2016-12-21-09-00-24 2](https://cloud.githubusercontent.com/assets/2915276/21382042/e1472e9a-c75e-11e6-91c0-f747d70515bb.jpg)


