### PR TITLE
Improve performance of collapsible animation

### DIFF
--- a/Collapsible/index.jsx
+++ b/Collapsible/index.jsx
@@ -1,6 +1,6 @@
 import React, {Component} from 'react'
-import {Motion, spring} from 'react-motion'
 import debounce from '../lib/debounce'
+import defaultStyles from './styles.scss'
 
 export default class Collapsible extends Component {
   constructor () {
@@ -50,22 +50,15 @@ export default class Collapsible extends Component {
     const {children, collapsed} = this.props
 
     return <div ref={(div) => { this.content = div }}>
-      <Motion style={{
-        height: spring(collapsed ? 0 : this.state.height),
-        opacity: spring(collapsed ? 0 : 1)
-      }}>
-        {({height, opacity}) => <div
-          style={{
-            height,
-            opacity,
-            // Overflow rule to enable content to overflow outside the collapsible
-            // once the animation is close to be complete (the last few pixels take a while
-            // to be expanded). '10' is a magic number 🎩
-            overflow: this.state.height - height > 10 ? 'hidden' : 'visible'
-          }}>
-          {children}
-        </div>}
-      </Motion>
+      <div
+        className={defaultStyles.wrapper}
+        style={{
+          height: collapsed ? 0 : this.state.height,
+          opacity: collapsed ? 0 : 1,
+          overflow: collapsed ? 'hidden' : 'visible'
+        }}>
+        {children}
+      </div>
     </div>
   }
 }

--- a/Collapsible/styles.scss
+++ b/Collapsible/styles.scss
@@ -1,3 +1,5 @@
 .wrapper {
-  transition: all 0.4s cubic-bezier(.02,.33,.44,1);
+  transition-duration: 0.4s;
+  transition-property: height, opacity;
+  transition-timing-function: cubic-bezier(.02,.33,.44,1);
 }

--- a/Collapsible/styles.scss
+++ b/Collapsible/styles.scss
@@ -1,0 +1,3 @@
+.wrapper {
+  transition: all 0.4s cubic-bezier(.02,.33,.44,1);
+}


### PR DESCRIPTION
React Motion was dragging IE9 to a hanging performance. CSS Transitions doesn’t work in there, but it is fine to not have transitions in browsers that do not support it.

The animation is not exactly the same, so we need a validation before proceeding.

![collapsible-animation](https://cloud.githubusercontent.com/assets/6001/21421777/ee1803f2-c834-11e6-9e2a-87d9eda2aca7.gif)
