### PR TITLE
Optimise Collapsible rendering

### DIFF
--- a/Collapsible/index.jsx
+++ b/Collapsible/index.jsx
@@ -1,6 +1,6 @@
 import React, {Component} from 'react'
-import {Motion, spring} from 'react-motion'
 import debounce from '../lib/debounce'
+import defaultStyles from './styles.scss'
 
 export default class Collapsible extends Component {
   constructor () {
@@ -49,22 +49,15 @@ export default class Collapsible extends Component {
     const {children, collapsed} = this.props
 
     return <div ref={(div) => { this.content = div }}>
-      <Motion style={{
-        height: spring(collapsed ? 0 : this.state.height),
-        opacity: spring(collapsed ? 0 : 1)
-      }}>
-        {({height, opacity}) => <div
-          style={{
-            height,
-            opacity,
-            // Overflow rule to enable content to overflow outside the collapsible
-            // once the animation is close to be complete (the last few pixels take a while
-            // to be expanded). '10' is a magic number 🎩
-            overflow: this.state.height - height > 10 ? 'hidden' : 'visible'
-          }}>
-          {children}
-        </div>}
-      </Motion>
+      <div
+        className={defaultStyles.wrapper}
+        style={{
+          height: collapsed ? 0 : this.state.height,
+          opacity: collapsed ? 0 : 1,
+          overflow: collapsed ? 'hidden' : 'visible'
+        }}>
+        {children}
+      </div>
     </div>
   }
 }

--- a/Collapsible/index.jsx
+++ b/Collapsible/index.jsx
@@ -7,8 +7,7 @@ export default class Collapsible extends Component {
     super()
 
     this.state = {
-      height: 0,
-      shouldRenderChildren: false
+      height: 0
     }
   }
 
@@ -27,25 +26,17 @@ export default class Collapsible extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    // The collapsed content is only rendered if it is expanded at least once
-    if (!nextProps.collapsed && !this.state.shouldRenderChildren) {
-      this.setState({ shouldRenderChildren: true })
-    }
+    this.updateHeight(nextProps)
   }
 
-  componentDidUpdate () {
-    this.updateHeight()
-  }
-
-  updateHeight () {
-    // We don't need to update the height of collapsed
-    // content (it will be zero)
-    if (this.props.collapsed) { return }
-
+  updateHeight (nextProps) {
     // Since update can happen asynchronously (debounced),
     // it might be executed after the component was already
     // unmounted.
     if (!this.content) { return }
+
+    // We don't need to update the height of collapsed
+    if (nextProps && nextProps.collapsed || !nextProps && this.props.collapsed) { return }
 
     const height = getHeight(this.content)
 
@@ -71,7 +62,7 @@ export default class Collapsible extends Component {
             // to be expanded). '10' is a magic number 🎩
             overflow: this.state.height - height > 10 ? 'hidden' : 'visible'
           }}>
-          {this.state.shouldRenderChildren && children}
+          {children}
         </div>}
       </Motion>
     </div>

--- a/Collapsible/index.jsx
+++ b/Collapsible/index.jsx
@@ -7,7 +7,8 @@ export default class Collapsible extends Component {
     super()
 
     this.state = {
-      height: 0
+      height: 0,
+      shouldRenderChildren: false
     }
   }
 
@@ -25,6 +26,13 @@ export default class Collapsible extends Component {
     window.removeEventListener('resize', this.debouncedResizeHandler)
   }
 
+  componentWillReceiveProps (nextProps) {
+    // The collapsed content is only rendered if it is expanded at least once
+    if (!nextProps.collapsed && !this.state.shouldRenderChildren) {
+      this.setState({ shouldRenderChildren: true })
+    }
+  }
+
   componentDidUpdate () {
     this.updateHeight()
   }
@@ -34,6 +42,10 @@ export default class Collapsible extends Component {
   }
 
   updateHeight () {
+    // We don't need to update the height of collapsed
+    // content (it will be zero)
+    if (this.props.collapsed) { return }
+
     // Since update can happen asynchronously (debounced),
     // it might be executed after the component was already
     // unmounted.
@@ -63,11 +75,19 @@ export default class Collapsible extends Component {
             // to be expanded). '10' is a magic number 🎩
             overflow: this.state.height - height > 10 ? 'hidden' : 'visible'
           }}>
-          {children}
+          {this.state.shouldRenderChildren && children}
         </div>}
       </Motion>
     </div>
   }
 }
 
-const getHeight = (node) => node.children[0].children[0].getBoundingClientRect().height
+const getHeight = (node) => {
+  const container = node.children[0]
+  if (!container) { return 0 }
+
+  const content = container.children[0]
+  if (!content) { return 0 }
+
+  return content.getBoundingClientRect().height
+}

--- a/Collapsible/index.jsx
+++ b/Collapsible/index.jsx
@@ -29,13 +29,17 @@ export default class Collapsible extends Component {
     this.updateHeight(nextProps)
   }
 
+  /**
+   * Updates the known height of the content, a very costly
+   * operation that should be done as little as possible.
+   */
   updateHeight (nextProps) {
     // Since update can happen asynchronously (debounced),
     // it might be executed after the component was already
     // unmounted.
     if (!this.content) { return }
 
-    // We don't need to update the height of collapsed
+    // We don't need to update the height of a collapsed content
     if (nextProps && nextProps.collapsed || !nextProps && this.props.collapsed) { return }
 
     const height = getHeight(this.content)

--- a/Collapsible/index.jsx
+++ b/Collapsible/index.jsx
@@ -13,8 +13,8 @@ export default class Collapsible extends Component {
   }
 
   componentDidMount () {
-    this.debouncedResizeHandler = debounce(() => this.onResize())
-    window.addEventListener('resize', this.debouncedResizeHandler)
+    this.debouncedUpdateHeight = debounce(() => this.updateHeight())
+    window.addEventListener('resize', this.debouncedUpdateHeight)
 
     this.updateHeight()
   }
@@ -23,7 +23,7 @@ export default class Collapsible extends Component {
     // Clean the reference to the content element since we are unmounting.
     // We check if it is defined in updateHeight before doing any update.
     this.content = null
-    window.removeEventListener('resize', this.debouncedResizeHandler)
+    window.removeEventListener('resize', this.debouncedUpdateHeight)
   }
 
   componentWillReceiveProps (nextProps) {
@@ -34,10 +34,6 @@ export default class Collapsible extends Component {
   }
 
   componentDidUpdate () {
-    this.updateHeight()
-  }
-
-  onResize () {
     this.updateHeight()
   }
 

--- a/Collapsible/styles.scss
+++ b/Collapsible/styles.scss
@@ -1,0 +1,5 @@
+.wrapper {
+  transition-duration: 0.4s;
+  transition-property: height, opacity;
+  transition-timing-function: cubic-bezier(.02,.33,.44,1);
+}

--- a/lib/debounce.js
+++ b/lib/debounce.js
@@ -1,11 +1,16 @@
-export default function debounce (func, time = 300) {
-  let timeoutId = null
+import requestAnimationFrame from './requestAnimationFrame'
 
-  return function () {
-    if (timeoutId) {
-      clearTimeout(timeoutId)
+export default function debounce (fn) {
+  let waiting = false
+
+  return function (...args) {
+    if (!waiting) {
+      waiting = true
+
+      requestAnimationFrame(() => {
+        fn(...args)
+        waiting = false
+      })
     }
-
-    timeoutId = setTimeout(func.bind(this, ...arguments), time)
   }
 }

--- a/lib/debounce.js
+++ b/lib/debounce.js
@@ -1,16 +1,11 @@
-import requestAnimationFrame from './requestAnimationFrame'
+export default function debounce (func, time = 300) {
+  let timeoutId = null
 
-export default function debounce (fn) {
-  let waiting = false
-
-  return function (...args) {
-    if (!waiting) {
-      waiting = true
-
-      requestAnimationFrame(() => {
-        fn(...args)
-        waiting = false
-      })
+  return function () {
+    if (timeoutId) {
+      clearTimeout(timeoutId)
     }
+
+    timeoutId = setTimeout(func.bind(this, ...arguments), time)
   }
 }


### PR DESCRIPTION
The are two big changes is this PR to improve the overall performance:

- Moved away from React Motion to CSS Transitions;
- Only calculate the height of the content if it is not collapsed or it is about to be expanded.

A caveat from this change is the new animation:

![collapsible-animation](https://cloud.githubusercontent.com/assets/6001/21545777/7cc1f590-cdda-11e6-9ddf-0d17fb44937f.gif)
