### PR TITLE
Move content from babelrc to package.json

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,0 @@
-{
-  "presets": [
-    "es2015",
-    "react",
-    "stage-0"
-  ]
-}

--- a/package.json
+++ b/package.json
@@ -90,5 +90,12 @@
       "it"
     ],
     "parser": "babel-eslint"
+  },
+  "babel": {
+    "presets": [
+      "es2015",
+      "react",
+      "stage-0"
+    ]
   }
 }


### PR DESCRIPTION
Having a .babelrc formatted for Babel 6 causes problems when running in a project using Babel 5.

Moving the content from .babelrc into package.json fixes the issue.