### PR TITLE
Revert "Move content from babelrc to package.json"

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": [
+    "es2015",
+    "react",
+    "stage-0"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -90,12 +90,5 @@
       "it"
     ],
     "parser": "babel-eslint"
-  },
-  "babel": {
-    "presets": [
-      "es2015",
-      "react",
-      "stage-0"
-    ]
   }
 }


### PR DESCRIPTION
This reverts #259. Unfortunately, it doesn't work, given Babel 5 still reads the contents of the `package.json` file in the dependencies.

A local project with Babel 5 has a postInstall "hack" that deletes all `.babelrc` files, making it work.

The real solution is to update this projects from Babel 5. But the bigger question is if we should publish the `.babelrc` to the npm registry at all.