### PR TITLE
Fix collapsisble hiding content

### DIFF
--- a/Collapsible/index.jsx
+++ b/Collapsible/index.jsx
@@ -25,22 +25,22 @@ export default class Collapsible extends Component {
     window.removeEventListener('resize', this.debouncedUpdateHeight)
   }
 
-  componentWillReceiveProps (nextProps) {
-    this.updateHeight(nextProps)
+  componentDidUpdate () {
+    this.updateHeight()
   }
 
   /**
    * Updates the known height of the content, a very costly
    * operation that should be done as little as possible.
    */
-  updateHeight (nextProps) {
+  updateHeight () {
     // Since update can happen asynchronously (debounced),
     // it might be executed after the component was already
     // unmounted.
     if (!this.content) { return }
 
     // We don't need to update the height of a collapsed content
-    if (nextProps && nextProps.collapsed || !nextProps && this.props.collapsed) { return }
+    if (this.props.collapsed) { return }
 
     const height = getHeight(this.content)
 

--- a/Collapsible/styles.scss
+++ b/Collapsible/styles.scss
@@ -1,5 +1,0 @@
-.wrapper {
-  transition-duration: 0.4s;
-  transition-property: height, opacity;
-  transition-timing-function: cubic-bezier(.02,.33,.44,1);
-}


### PR DESCRIPTION
- Once the Collapsible has completely expanded, we set the height to ‘auto’
- No longer we need to listen to window resize events!
- Put React Motion back (easier to implement and not really the biggest performance penalty anyway)
