### PR TITLE
Fix Collapsible calculating height all the time

### DIFF
--- a/Collapsible/index.jsx
+++ b/Collapsible/index.jsx
@@ -17,7 +17,7 @@ export default class Collapsible extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    if (!this.props.collapsed !== nextProps.collapsed) {
+    if (!nextProps.collapsed && this.props.collapsed) {
       this.setState({ height: calculateHeight(this.content) })
     }
   }
@@ -34,7 +34,7 @@ export default class Collapsible extends Component {
           style={{
             // once it is fully expanded, we set the heigh to auto
             // and let the browser take care of the size
-            height: height === this.state.height ? 'auto' : height,
+            height: getHeight(collapsed, height, this.state.height),
             opacity,
             // Overflow rule to enable content to overflow outside the collapsible
             // once the animation is close to be complete (the last few pixels take a while
@@ -46,6 +46,11 @@ export default class Collapsible extends Component {
       </Motion>
     </div>
   }
+}
+
+const getHeight = (collapsed, animatedHeight, actualHeight) => {
+  if (collapsed) { return animatedHeight }
+  return animatedHeight === actualHeight ? 'auto' : animatedHeight
 }
 
 const calculateHeight = (node) => {


### PR DESCRIPTION
The check in `componentWillReceiveProps` was incorrect, leading to calculations being performed on every prop change.

And since we can now have components that don’t have the height on first render, we need a check in the Motion height against the `collapsed` prop, otherwise the Collapsible would show expanded (not opacity) on first render.