### PR TITLE
Remove browserlist from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@ tests
 *.ttf
 example-built.js
 example-built.js.map
+browserslist

--- a/browserslist
+++ b/browserslist
@@ -1,38 +1,6 @@
-and_chr 53
-and_uc 11
-android 4.4.3-4.4.4
-android 4.4
-chrome 54
-chrome 53
-chrome 52
-chrome 51
-chrome 49
-edge 14
-edge 13
-edge 12
-firefox 49
-firefox 48
-firefox 47
-firefox 46
-firefox 45
-ie 11
-ie 10
-ie 9
-ie 8
-ie_mob 11
-ie_mob 10
-ios_saf 10
-ios_saf 9.3
-ios_saf 9.0-9.2
-ios_saf 8.1-8.4
-ios_saf 8
-op_mini all
-opera 41
-opera 40
-opera 39
-opera 38
-safari 10
-safari 9.1
-safari 9
-safari 8
-samsung 4
+# Browsers that we support
+
+> 1%
+Last 2 versions
+IE 10 # sorry
+IE 9


### PR DESCRIPTION
This is to fix #268

This will be a breaking change when merged since some consumers might be relying on the browserslist for their autoprefixer setup.