### PR TITLE
Set less strict propType for components children

### DIFF
--- a/Alert/index.jsx
+++ b/Alert/index.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
+import childrenPropType from '../propTypes/children'
 
 const baseClass = 'alert'
 
@@ -26,7 +27,7 @@ export function Error ({ children, className, styles, ...remainingProps }) {
 Error.displayName = 'Alert.Error'
 
 Error.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   id: PropTypes.string,
   styles: PropTypes.object
@@ -47,7 +48,7 @@ export function Warning ({ children, className, styles, ...remainingProps }) {
 Warning.displayName = 'Alert.Warning'
 
 Warning.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   id: PropTypes.string,
   styles: PropTypes.object
@@ -68,7 +69,7 @@ export function Title ({ children, className, styles, ...remainingProps }) {
 Title.displayName = 'Alert.Title'
 
 Title.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   id: PropTypes.string,
   styles: PropTypes.object
@@ -89,7 +90,7 @@ export function Paragraph ({ children, className, styles, ...remainingProps }) {
 Paragraph.displayName = 'Alert.Paragraph'
 
 Paragraph.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   id: PropTypes.string,
   styles: PropTypes.object

--- a/Amount/index.jsx
+++ b/Amount/index.jsx
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
 import palette from '../lib/palette'
+import childrenPropType from '../propTypes/children'
 
 const baseClass = 'amount-text'
 
@@ -23,7 +24,7 @@ Amount.defaultProps = {
 
 Amount.propTypes = {
   color: PropTypes.oneOf(palette),
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   id: PropTypes.string,
   styles: PropTypes.object

--- a/Block/Content/index.jsx
+++ b/Block/Content/index.jsx
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'block--content'
 
@@ -15,7 +16,7 @@ export default function Content ({ children, className, styles, ...props }) {
 Content.displayName = 'Block.Content'
 
 Content.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   id: PropTypes.string,
   styles: PropTypes.object

--- a/Block/Installments/index.jsx
+++ b/Block/Installments/index.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'block--installments'
 
@@ -27,7 +28,7 @@ Main.displayName = 'Block.Installments.Main'
 
 Main.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
+  children: childrenPropType,
   id: PropTypes.string,
   styles: PropTypes.object
 }
@@ -46,7 +47,7 @@ Title.displayName = 'Block.Installments.Title'
 
 Title.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
+  children: childrenPropType,
   id: PropTypes.string,
   styles: PropTypes.object
 }
@@ -65,7 +66,7 @@ Content.displayName = 'Block.Installments.Content'
 
 Content.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
+  children: childrenPropType,
   id: PropTypes.string,
   styles: PropTypes.object
 }
@@ -112,7 +113,7 @@ Value.displayName = 'Block.Installments.Value'
 Value.propTypes = {
   clarification: PropTypes.string,
   className: PropTypes.string,
-  children: PropTypes.node,
+  children: childrenPropType,
   id: PropTypes.string,
   title: PropTypes.string.isRequired,
   styles: PropTypes.object,

--- a/Block/Plain/index.jsx
+++ b/Block/Plain/index.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'block'
 
@@ -20,7 +21,7 @@ Plain.displayName = 'Block.Plain'
 
 Plain.propTypes = {
   blue: PropTypes.bool,
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   id: PropTypes.string,
   styles: PropTypes.object

--- a/Button/Price/index.jsx
+++ b/Button/Price/index.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react'
 import defaultStyles from '../styles.scss'
+import childrenPropType from '../../propTypes/children'
 
 export default function Price ({ children, ...props }) {
   return (
@@ -12,6 +13,6 @@ export default function Price ({ children, ...props }) {
 Price.displayName = 'Button.Price'
 
 Price.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   id: PropTypes.string
 }

--- a/Button/Primary/index.jsx
+++ b/Button/Primary/index.jsx
@@ -9,6 +9,7 @@ import Price from '../Price'
 import themeable from '../../decorators/themeable'
 import overridable from '../../decorators/overridable'
 import brandVolumeLevels from '../../lib/brandVolumeLevels'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'button'
 
@@ -105,7 +106,7 @@ Primary.defaultProps = {
 
 Primary.propTypes = {
   brandVolume: PropTypes.oneOf(brandVolumeLevels),
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   customize: PropTypes.shape({
     backgroundColor: PropTypes.string.isRequired,

--- a/Button/Secondary/index.jsx
+++ b/Button/Secondary/index.jsx
@@ -9,6 +9,7 @@ import themeable from '../../decorators/themeable'
 import overridable from '../../decorators/overridable'
 import brandVolumeLevels from '../../lib/brandVolumeLevels'
 import defaultStyles from '../styles.scss'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'button'
 
@@ -124,7 +125,7 @@ Secondary.defaultProps = {
 
 Secondary.propTypes = {
   brandVolume: PropTypes.oneOf(brandVolumeLevels),
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   customize: PropTypes.shape({
     backgroundColor: PropTypes.string.isRequired,

--- a/Button/Tertiary/index.jsx
+++ b/Button/Tertiary/index.jsx
@@ -8,6 +8,7 @@ import compose from '../../lib/compose'
 import themeable from '../../decorators/themeable'
 import overridable from '../../decorators/overridable'
 import defaultStyles from '../styles.scss'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'button'
 
@@ -114,7 +115,7 @@ Tertiary.defaultProps = {
 }
 
 Tertiary.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   customize: PropTypes.shape({
     backgroundColor: PropTypes.string.isRequired,

--- a/Checklist/index.jsx
+++ b/Checklist/index.jsx
@@ -4,6 +4,7 @@ import themeable from '../decorators/themeable'
 import overridable from '../decorators/overridable'
 import compose from '../lib/compose'
 import defaultStyles from './styles.scss'
+import childrenPropType from '../propTypes/children'
 
 const baseClass = 'checklist'
 
@@ -36,7 +37,7 @@ ChecklistMain.displayName = 'Checklist.Main'
 
 ChecklistMain.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
+  children: childrenPropType,
   chromeless: PropTypes.bool,
   id: PropTypes.string,
   styles: PropTypes.object,
@@ -93,7 +94,7 @@ ChecklistItem.displayName = 'Checklist.Item'
 
 ChecklistItem.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
+  children: childrenPropType,
   id: PropTypes.string,
   styles: PropTypes.object,
   customize: PropTypes.shape({

--- a/ContextMenu/index.jsx
+++ b/ContextMenu/index.jsx
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
+import childrenPropType from '../propTypes/children'
 
 const baseClass = 'context-menu'
 
@@ -24,7 +25,7 @@ Main.displayName = 'ContextMenu.Main'
 
 Main.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
+  children: childrenPropType,
   id: PropTypes.string,
   styles: PropTypes.object
 }
@@ -52,7 +53,7 @@ Link.displayName = 'ContextMenu.Link'
 
 Link.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
+  children: childrenPropType,
   id: PropTypes.string,
   styles: PropTypes.object
 }
@@ -71,7 +72,7 @@ Item.displayName = 'ContextMenu.Item'
 
 Item.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
+  children: childrenPropType,
   id: PropTypes.string,
   styles: PropTypes.object
 }

--- a/Dialog/index.jsx
+++ b/Dialog/index.jsx
@@ -4,6 +4,7 @@ import compose from '../lib/compose'
 import defaultStyles from './styles.scss'
 import themeable from '../decorators/themeable'
 import overridable from '../decorators/overridable'
+import childrenPropType from '../propTypes/children'
 
 const baseClass = 'dialog'
 
@@ -42,7 +43,7 @@ function DialogMain ({children, className, customize, style, styles, ...props}) 
 DialogMain.displayName = 'Dialog.Main'
 
 DialogMain.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   id: PropTypes.string,
   styles: PropTypes.object
@@ -73,7 +74,7 @@ export function Icon ({children, className, left, styles, ...props}) {
 Icon.displayName = 'Dialog.Icon'
 
 Icon.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   id: PropTypes.string,
   left: PropTypes.bool,
@@ -104,7 +105,7 @@ export function Content ({children, className, id, styles, ...props}) {
 Content.displayName = 'Dialog.Content'
 
 Content.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   id: PropTypes.string,
   styles: PropTypes.object
@@ -134,7 +135,7 @@ export function Footer ({children, className, id, styles, ...props}) {
 Footer.displayName = 'Dialog.Footer'
 
 Footer.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   id: PropTypes.string,
   styles: PropTypes.object
@@ -177,7 +178,7 @@ export function Overlay ({
 Overlay.displayName = 'Dialog.Overlay'
 
 Overlay.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   id: PropTypes.string,
   show: PropTypes.bool,

--- a/Fieldset/index.jsx
+++ b/Fieldset/index.jsx
@@ -6,6 +6,7 @@ import compose from '../lib/compose'
 import uncontrolled from '../decorators/uncontrolled'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
+import childrenPropType from '../propTypes/children'
 
 function Fieldset ({
   className,
@@ -66,7 +67,7 @@ Fieldset.defaultProps = {
 }
 
 Fieldset.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   fields: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string.isRequired,

--- a/Label/index.jsx
+++ b/Label/index.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
+import childrenPropType from '../propTypes/children'
 
 const baseClass = 'label'
 
@@ -39,7 +40,7 @@ export default function Label ({
 }
 
 Label.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   design: PropTypes.oneOf(designs),
   id: PropTypes.string,

--- a/Link/index.jsx
+++ b/Link/index.jsx
@@ -5,6 +5,7 @@ import palette from '../lib/palette'
 import compose from '../lib/compose'
 import themeable from '../decorators/themeable'
 import overridable from '../decorators/overridable'
+import childrenPropType from '../propTypes/children'
 
 const baseClass = 'link'
 
@@ -40,7 +41,7 @@ function Link ({
 }
 
 Link.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   color: PropTypes.oneOf(palette),
   customize: PropTypes.shape({

--- a/List/Iconic/index.jsx
+++ b/List/Iconic/index.jsx
@@ -2,6 +2,7 @@ import React, {PropTypes} from 'react'
 import * as Paragraph from '../../Paragraph'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'list--iconic'
 
@@ -24,7 +25,7 @@ Wrapper.displayName = 'List.Iconic.Wrapper'
 
 Wrapper.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
+  children: childrenPropType,
   id: PropTypes.string,
   styles: PropTypes.object
 }
@@ -65,7 +66,7 @@ Item.displayName = 'List.Iconic.Item'
 
 Item.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
+  children: childrenPropType,
   icon: PropTypes.node,
   id: PropTypes.string,
   styles: PropTypes.object

--- a/List/Item/index.jsx
+++ b/List/Item/index.jsx
@@ -4,6 +4,7 @@ import themeable from '../../decorators/themeable'
 import overridable from '../../decorators/overridable'
 import compose from '../../lib/compose'
 import defaultStyles from '../styles.scss'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'list__item'
 
@@ -42,7 +43,7 @@ Item.displayName = 'List.Item'
 
 Item.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
+  children: childrenPropType,
   color: PropTypes.string,
   condensed: PropTypes.bool,
   id: PropTypes.string,

--- a/List/Ordered/index.jsx
+++ b/List/Ordered/index.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from '../styles.scss'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'list--ordered'
 
@@ -16,7 +17,7 @@ export default function Ordered ({children, className, styles, ...props}) {
 Ordered.displayName = 'List.Ordered'
 
 Ordered.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   id: PropTypes.string,
   style: PropTypes.object,

--- a/List/Unordered/index.jsx
+++ b/List/Unordered/index.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from '../styles.scss'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'list--unordered'
 
@@ -16,7 +17,7 @@ export default function Unordered ({children, className, styles, ...props}) {
 Unordered.displayName = 'List.Unordered'
 
 Unordered.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   id: PropTypes.string,
   styles: PropTypes.object

--- a/Menu/Segmented/index.jsx
+++ b/Menu/Segmented/index.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'segmented'
 
@@ -15,7 +16,7 @@ export default React.createClass({
   displayName: 'Segmented',
 
   propTypes: {
-    children: PropTypes.node,
+    children: childrenPropType,
     className: PropTypes.string,
     id: PropTypes.string,
     name: PropTypes.string.isRequired,

--- a/Paragraph/Legal/index.jsx
+++ b/Paragraph/Legal/index.jsx
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
 import palette from '../../lib/palette'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'paragraph--legal'
 
@@ -41,7 +42,7 @@ Legal.defaultProps = {
 }
 
 Legal.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   color: PropTypes.oneOf(palette),
   condensed: PropTypes.bool,

--- a/Paragraph/Primary/index.jsx
+++ b/Paragraph/Primary/index.jsx
@@ -6,6 +6,7 @@ import defaultStyles from './styles.scss'
 import palette from '../../lib/palette'
 import compose from '../../lib/compose'
 import isThemeable from '../../Text/isThemeable'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'paragraph--primary'
 
@@ -45,7 +46,7 @@ Primary.defaultProps = {
 }
 
 Primary.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   color: PropTypes.oneOf(palette),
   condensed: PropTypes.bool,

--- a/Paragraph/Secondary/index.jsx
+++ b/Paragraph/Secondary/index.jsx
@@ -6,6 +6,7 @@ import defaultStyles from './styles.scss'
 import palette from '../../lib/palette'
 import compose from '../../lib/compose'
 import isThemeable from '../../Text/isThemeable'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'paragraph--secondary'
 
@@ -45,7 +46,7 @@ Secondary.defaultProps = {
 }
 
 Secondary.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   color: PropTypes.oneOf(palette),
   condensed: PropTypes.bool,

--- a/Preview/index.jsx
+++ b/Preview/index.jsx
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import contains from '../lib/contains'
 import defaultStyles from './styles.scss'
+import childrenPropType from '../propTypes/children'
 
 const baseClass = 'preview'
 
@@ -31,7 +32,7 @@ Main.displayName = 'Preview.Main'
 
 Main.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
+  children: childrenPropType,
   id: PropTypes.string,
   styles: PropTypes.object
 }
@@ -50,7 +51,7 @@ Content.displayName = 'Preview.Content'
 
 Content.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
+  children: childrenPropType,
   id: PropTypes.string,
   styles: PropTypes.object
 }
@@ -69,7 +70,7 @@ Title.displayName = 'Preview.Title'
 
 Title.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
+  children: childrenPropType,
   id: PropTypes.string,
   styles: PropTypes.object
 }
@@ -97,7 +98,7 @@ Link.displayName = 'Preview.Link'
 
 Link.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
+  children: childrenPropType,
   id: PropTypes.string,
   styles: PropTypes.object
 }

--- a/Strong/index.jsx
+++ b/Strong/index.jsx
@@ -3,6 +3,7 @@ import classNamesBind from 'classnames/bind'
 import compose from '../lib/compose'
 import overridable from '../decorators/overridable'
 import defaultStyles from './styles.scss'
+import childrenPropType from '../propTypes/children'
 
 const baseClass = 'strong'
 
@@ -19,7 +20,7 @@ Strong.defaultProps = {
 }
 
 Strong.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   id: PropTypes.string,
   styles: PropTypes.object
 }

--- a/Subtitle/index.jsx
+++ b/Subtitle/index.jsx
@@ -6,6 +6,7 @@ import defaultStyles from './styles.scss'
 import palette from '../lib/palette'
 import compose from '../lib/compose'
 import isThemeable from '../Text/isThemeable'
+import childrenPropType from '../propTypes/children'
 
 const baseClass = 'subtitle'
 
@@ -44,7 +45,7 @@ Subtitle.defaultProps = {
 }
 
 Subtitle.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   color: PropTypes.oneOf(palette),
   id: PropTypes.string,

--- a/Switch/Checkbox/index.jsx
+++ b/Switch/Checkbox/index.jsx
@@ -4,6 +4,7 @@ import themeable from '../../decorators/themeable'
 import overridable from '../../decorators/overridable'
 import compose from '../../lib/compose'
 import defaultStyles from './styles.scss'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'switch--checkbox'
 
@@ -35,7 +36,7 @@ const Checkbox = React.createClass({
 
   propTypes: {
     align: PropTypes.oneOf(alignments),
-    children: PropTypes.node,
+    children: childrenPropType,
     className: PropTypes.string,
     customize: PropTypes.shape({
       backgroundColor: PropTypes.string.isRequired,

--- a/Switch/Toggle/index.jsx
+++ b/Switch/Toggle/index.jsx
@@ -4,6 +4,7 @@ import themeable from '../../decorators/themeable'
 import overridable from '../../decorators/overridable'
 import compose from '../../lib/compose'
 import defaultStyles from './styles.scss'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'switch'
 
@@ -112,7 +113,7 @@ const Toggle = React.createClass({
   },
 
   propTypes: {
-    children: PropTypes.node,
+    children: childrenPropType,
     className: PropTypes.string,
     customize: PropTypes.shape({
       backgroundColor: PropTypes.string.isRequired,

--- a/TextLabel/index.jsx
+++ b/TextLabel/index.jsx
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
 import palette from '../lib/palette'
+import childrenPropType from '../propTypes/children'
 
 const baseClass = 'text-label'
 
@@ -30,7 +31,7 @@ TextLabel.defaultProps = {
 }
 
 TextLabel.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   color: PropTypes.oneOf(palette),
   id: PropTypes.string,

--- a/Title/Primary/index.jsx
+++ b/Title/Primary/index.jsx
@@ -6,6 +6,7 @@ import defaultStyles from './styles.scss'
 import palette from '../../lib/palette'
 import compose from '../../lib/compose'
 import isThemeable from '../../Text/isThemeable'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'title--primary'
 
@@ -50,7 +51,7 @@ Primary.defaultProps = {
 }
 
 Primary.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   color: PropTypes.oneOf(palette),
   id: PropTypes.string,

--- a/Title/Secondary/index.jsx
+++ b/Title/Secondary/index.jsx
@@ -6,6 +6,7 @@ import defaultStyles from './styles.scss'
 import palette from '../../lib/palette'
 import compose from '../../lib/compose'
 import isThemeable from '../../Text/isThemeable'
+import childrenPropType from '../../propTypes/children'
 
 const baseClass = 'title--secondary'
 
@@ -47,7 +48,7 @@ Secondary.defaultProps = {
 }
 
 Secondary.propTypes = {
-  children: PropTypes.node,
+  children: childrenPropType,
   className: PropTypes.string,
   color: PropTypes.oneOf(palette),
   condensed: PropTypes.bool,

--- a/Tooltip/index.jsx
+++ b/Tooltip/index.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
+import childrenPropType from '../propTypes/children'
 
 const baseClass = 'tooltip'
 
@@ -23,7 +24,7 @@ export default function Tooltip ({ className, arrow, children, inverse, styles, 
 Tooltip.propTypes = {
   className: PropTypes.string,
   arrow: PropTypes.oneOf(arrows),
-  children: PropTypes.node,
+  children: childrenPropType,
   id: PropTypes.string,
   inverse: PropTypes.bool,
   styles: PropTypes.object

--- a/propTypes/children.js
+++ b/propTypes/children.js
@@ -1,0 +1,7 @@
+import { PropTypes } from 'react'
+
+export default PropTypes.oneOfType([
+  PropTypes.arrayOf(PropTypes.node),
+  PropTypes.node,
+  PropTypes.func
+])


### PR DESCRIPTION
We were getting some propType warnings when defining an array of nodes or a function as children of UI components. This patch makes all components children support these types.