### PR TITLE
Selector Input

### DIFF
--- a/Button/example.jsx
+++ b/Button/example.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Back, Close, Select, Hamburger, Options, Search } from '../IconButton'
+import { Back, Close, Hamburger, Options, Search, Select } from '../IconButton'
 import * as Block from '../Block'
 import * as Button from '../Button'
 // import * as Paragraph from '../Paragraph'
@@ -229,7 +229,7 @@ export default {
 
     {
       title: 'Iconic Buttons',
-      require: 'import { Back, Close, Hamburger, Options, Search } from \'@klarna/ui/IconButton\'',
+      require: 'import { Back, Close, Hamburger, Options, Search, Select } from \'@klarna/ui/IconButton\'',
       type: LIVE,
 
       examples: {

--- a/Button/example.jsx
+++ b/Button/example.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Back, Close, Hamburger, Options, Search } from '../IconButton'
+import { Back, Close, Select, Hamburger, Options, Search } from '../IconButton'
 import * as Block from '../Block'
 import * as Button from '../Button'
 // import * as Paragraph from '../Paragraph'
@@ -263,6 +263,10 @@ export default {
           </Block.Plain>,
 
           <Block.Plain key='1' style={{padding: '20px'}}>
+            <Select label='Select' />
+          </Block.Plain>,
+
+          <Block.Plain key='2' style={{padding: '20px'}}>
             <Close label='Close' color='gray' left />
           </Block.Plain>
         ],

--- a/IconButton/Select/index.jsx
+++ b/IconButton/Select/index.jsx
@@ -1,0 +1,66 @@
+import React, { PropTypes } from 'react'
+import classNamesBind from 'classnames/bind'
+import themeable from '../../decorators/themeable'
+import overridable from '../../decorators/overridable'
+import compose from '../../lib/compose'
+import defaultStyles from '../styles.scss'
+import withDisplayName from '../withDisplayName'
+
+const classes = {
+  iconButton: 'icon-button',
+  fill: 'illustration__fill',
+  label: 'illustration__label',
+  labelLight: 'illustration__label--light',
+  stroke: 'illustration__stroke'
+}
+
+const Select = ({className, color, id, label, left, styles, ...props}) => {
+  const classNames = classNamesBind.bind({...defaultStyles, ...styles})
+  const ids = id
+    ? {
+      illustration: `${id}__illustration`,
+      label: `${id}__label`
+    } : {}
+
+  return <div
+    className={classNames(classes.iconButton, className)}
+    id={id}
+    {...props}>
+    <svg
+      className={classNames('illustration', 'button', color)}
+      id={ids.illustration}
+      strokeLinecap='round'
+      strokeWidth='2'
+      viewBox='0 0 21 21'
+      height='20px'
+      width='20px'>
+      <path
+        className={classNames(classes.stroke)}
+        d='M9,6l4,4l-4,4'
+      />
+    </svg>
+
+    <span
+      className={classNames(classes.label, classes.labelLight, { left }, color)}
+      id={ids.label}>
+      {label}
+    </span>
+  </div>
+}
+
+Select.defaultProps = {
+  left: true
+}
+
+Select.propTypes = {
+  className: PropTypes.string,
+  color: PropTypes.oneOf(['gray', 'inverse', 'blue']),
+  id: PropTypes.string,
+  styles: PropTypes.object
+}
+
+export default compose(
+  themeable(() => ({color: 'gray'})),
+  overridable(defaultStyles),
+  withDisplayName('Select')
+)(Select)

--- a/IconButton/index.jsx
+++ b/IconButton/index.jsx
@@ -1,5 +1,6 @@
 export Back from './Back'
 export Close from './Close'
+export Select from './Select'
 export Hamburger from './Hamburger'
 export Options from './Options'
 export Search from './Search'

--- a/IconButton/styles.scss
+++ b/IconButton/styles.scss
@@ -30,7 +30,6 @@
     }
   }
 
-
   &:hover {
     .illustration.button {
       @include illustration(map-get($colors, klarna-blue-hover));
@@ -89,6 +88,7 @@
   top: 0;
   transition: color .2s ease;
   user-select: none;
+  white-space: nowrap;
 
   &.left {
     left: auto;
@@ -102,5 +102,10 @@
 
   &.inverse {
     color: map-get($colors, white);
+  }
+
+  &--light {
+    font-weight: map-get($font-weights, regular);
+    text-transform: none;
   }
 }

--- a/Selector/Input/index.jsx
+++ b/Selector/Input/index.jsx
@@ -10,7 +10,7 @@ import { Select } from '../../IconButton'
 import themeable from '../../decorators/themeable'
 import overridable from '../../decorators/overridable'
 
-const baseClass = 'input'
+const baseClass = 'selector-input'
 
 const classes = {
   icon: `${baseClass}--icon`,

--- a/Selector/Input/index.jsx
+++ b/Selector/Input/index.jsx
@@ -1,0 +1,187 @@
+import React, { PropTypes } from 'react'
+import classNamesBind from 'classnames/bind'
+import defaultStyles from './styles.scss'
+import * as programmaticFocus from '../../lib/features/programmaticFocus'
+import * as fieldStates from '../../lib/features/fieldStates'
+import * as inlinedIcon from '../../lib/features/inlinedIcon'
+import * as stacking from '../../lib/features/stacking'
+import { handleKeyDown } from '../../lib/features/keyboardEvents'
+import MouseflowExclude from '../../MouseflowExclude'
+import { Select } from '../../IconButton'
+
+const baseClass = 'input'
+
+const classes = {
+  icon: `${baseClass}--icon`,
+  iconIcon: `${baseClass}--icon__icon`,
+  iconIconFill: `${baseClass}--icon__icon__fill`,
+  iconIconStroke: `${baseClass}--icon__icon__stroke`,
+  iconInput: `${baseClass}--icon__input`,
+  iconLabel: `${baseClass}--icon__label`,
+  input: `${baseClass}__input`,
+  inputPlaceholder: `${baseClass}__input-placeholder`,
+  label: `${baseClass}__label`,
+  linkWrapper: `${baseClass}__link-wrapper`,
+}
+
+export const icons = inlinedIcon.INLINED_ICONS
+
+export default React.createClass({
+  displayName: 'Input',
+
+  getDefaultProps () {
+    return {
+      big: false,
+      centered: false,
+      giant: false,
+      loading: false,
+      mouseflowExclude: false,
+      onChange: function () {},
+      ...inlinedIcon.defaultProps,
+      ...fieldStates.defaultProps,
+      ...stacking.position.defaultProps,
+      ...handleKeyDown.defaultProps,
+      ...stacking.size.defaultProps
+    }
+  },
+
+  propTypes: {
+    big: PropTypes.bool,
+    centered: PropTypes.bool,
+    giant: PropTypes.bool,
+    id: PropTypes.string,
+    input: PropTypes.func,
+    loading: PropTypes.bool,
+    label: PropTypes.string.isRequired,
+    mouseflowExclude: PropTypes.bool,
+    onBlur: PropTypes.func,
+    onChange: PropTypes.func,
+    onClick: PropTypes.func,
+    onFocus: PropTypes.func,
+    value: PropTypes.string,
+    styles: PropTypes.object,
+    ...inlinedIcon.propTypes,
+    ...fieldStates.propTypes,
+    ...handleKeyDown.propTypes,
+    ...stacking.position.propTypes,
+    ...programmaticFocus.propTypes,
+    ...stacking.size.propTypes
+  },
+
+  componentDidMount () {
+    programmaticFocus.maybeFocus(document)(this.props.focus, this.refs.input)
+  },
+
+  componentDidUpdate () {
+    programmaticFocus.maybeFocus(document)(this.props.focus, this.refs.input)
+  },
+
+  render () {
+    const {
+      big,
+      bottom, // eslint-disable-line no-unused-vars
+      className,
+      center, // eslint-disable-line no-unused-vars
+      centered,
+      disabled,
+      error, // eslint-disable-line no-unused-vars
+      focus, // eslint-disable-line no-unused-vars
+      giant,
+      icon,
+      id,
+      Input,
+      label,
+      left, // eslint-disable-line no-unused-vars
+      loading,
+      mouseflowExclude,
+      onBlur,
+      onChange,
+      onClick,
+      onEnter, // eslint-disable-line no-unused-vars
+      onFocus,
+      onTab, // eslint-disable-line no-unused-vars
+      placeholder,
+      right, // eslint-disable-line no-unused-vars
+      square,
+      styles,
+      top, // eslint-disable-line no-unused-vars
+      value,
+      warning, // eslint-disable-line no-unused-vars
+      ...props
+    } = this.props
+    const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+
+    const cls = classNames(
+      (icon ? classes.icon : baseClass), {
+        big,
+        giant,
+        'is-centered': centered,
+        'is-filled': value != null && value !== '',
+        'is-loading': loading,
+        square
+      },
+      fieldStates.getClassName(this.props),
+      programmaticFocus.getClassName(this.props),
+      stacking.size.getClassName(this.props),
+      stacking.position.getClassName(this.props),
+      className
+    )
+
+    const ids = id
+      ? {
+        input: `${id}__input`,
+        label: `${id}__label`
+      } : {}
+
+    const inputProps = {
+      className: classNames(icon ? classes.iconInput : classes.input),
+      disabled: disabled,
+      id: ids.input,
+      onBlur: onBlur,
+      onChange: onChange,
+      onKeyDown: handleKeyDown(this.props),
+      onFocus: onFocus,
+      ref: 'input',
+      ...props
+    }
+
+    const inputElement = (
+      <div {...inputProps}>
+        {
+          placeholder
+          ? <span className={classNames(classes.inputPlaceholder)}>{placeholder}</span>
+          : value
+        }
+      </div>
+    )
+
+    return (
+      <div
+        className={cls}
+        id={id}
+        onClick={onClick}>
+        {
+          inlinedIcon.renderInlinedIcon(this.props, {
+            icon: classNames(classes.iconIcon),
+            fill: classNames(classes.iconIconFill),
+            stroke: classNames(classes.iconIconStroke)
+          })
+        }
+
+        <label
+          className={classNames(icon ? classes.iconLabel : classes.label)}
+          id={ids.label}>
+          {label}
+        </label>
+
+        {mouseflowExclude
+          ? <MouseflowExclude>{inputElement}</MouseflowExclude>
+          : inputElement
+        }
+        <div className={classNames(classes.linkWrapper)}>
+          <Select label={'Select'} />
+        </div>
+      </div>
+    )
+  }
+})

--- a/Selector/Input/index.jsx
+++ b/Selector/Input/index.jsx
@@ -24,7 +24,7 @@ const classes = {
   input: `${baseClass}__input`,
   inputPlaceholder: `${baseClass}__input-placeholder`,
   label: `${baseClass}__label`,
-  linkWrapper: `${baseClass}__link-wrapper`,
+  linkWrapper: `${baseClass}__link-wrapper`
 }
 
 export const icons = inlinedIcon.INLINED_ICONS
@@ -111,7 +111,6 @@ const SelectorInput = React.createClass({
       giant,
       icon,
       id,
-      Input,
       label,
       left, // eslint-disable-line no-unused-vars
       loading,

--- a/Selector/Input/index.jsx
+++ b/Selector/Input/index.jsx
@@ -64,6 +64,7 @@ const SelectorInput = React.createClass({
     giant: PropTypes.bool,
     id: PropTypes.string,
     input: PropTypes.func,
+    link: PropTypes.string,
     loading: PropTypes.bool,
     label: PropTypes.string.isRequired,
     mouseflowExclude: PropTypes.bool,
@@ -113,6 +114,7 @@ const SelectorInput = React.createClass({
       id,
       label,
       left, // eslint-disable-line no-unused-vars
+      link,
       loading,
       mouseflowExclude,
       onBlur,
@@ -228,7 +230,7 @@ const SelectorInput = React.createClass({
           : inputElement
         }
         <div className={classNames(classes.linkWrapper)}>
-          <Select label={'Select'} />
+          <Select label={link} />
         </div>
       </div>
     )

--- a/Selector/Input/index.jsx
+++ b/Selector/Input/index.jsx
@@ -2,11 +2,9 @@ import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import compose from '../../lib/compose'
 import defaultStyles from './styles.scss'
-import * as programmaticFocus from '../../lib/features/programmaticFocus'
 import * as fieldStates from '../../lib/features/fieldStates'
 import * as inlinedIcon from '../../lib/features/inlinedIcon'
 import * as stacking from '../../lib/features/stacking'
-import { handleKeyDown } from '../../lib/features/keyboardEvents'
 import MouseflowExclude from '../../MouseflowExclude'
 import { Select } from '../../IconButton'
 import themeable from '../../decorators/themeable'
@@ -39,11 +37,9 @@ const SelectorInput = React.createClass({
       giant: false,
       loading: false,
       mouseflowExclude: false,
-      onChange: function () {},
       ...inlinedIcon.defaultProps,
       ...fieldStates.defaultProps,
       ...stacking.position.defaultProps,
-      ...handleKeyDown.defaultProps,
       ...stacking.size.defaultProps
     }
   },
@@ -68,26 +64,13 @@ const SelectorInput = React.createClass({
     loading: PropTypes.bool,
     label: PropTypes.string.isRequired,
     mouseflowExclude: PropTypes.bool,
-    onBlur: PropTypes.func,
-    onChange: PropTypes.func,
     onClick: PropTypes.func,
-    onFocus: PropTypes.func,
     value: PropTypes.string,
     styles: PropTypes.object,
     ...inlinedIcon.propTypes,
     ...fieldStates.propTypes,
-    ...handleKeyDown.propTypes,
     ...stacking.position.propTypes,
-    ...programmaticFocus.propTypes,
     ...stacking.size.propTypes
-  },
-
-  componentDidMount () {
-    programmaticFocus.maybeFocus(document)(this.props.focus, this.refs.input)
-  },
-
-  componentDidUpdate () {
-    programmaticFocus.maybeFocus(document)(this.props.focus, this.refs.input)
   },
 
   onMouseEnter () {
@@ -107,8 +90,7 @@ const SelectorInput = React.createClass({
       centered,
       customize,
       disabled,
-      error, // eslint-disable-line no-unused-vars
-      focus, // eslint-disable-line no-unused-vars
+      error,
       giant,
       icon,
       id,
@@ -117,12 +99,7 @@ const SelectorInput = React.createClass({
       link,
       loading,
       mouseflowExclude,
-      onBlur,
-      onChange,
       onClick,
-      onEnter, // eslint-disable-line no-unused-vars
-      onFocus,
-      onTab, // eslint-disable-line no-unused-vars
       placeholder,
       right, // eslint-disable-line no-unused-vars
       square,
@@ -130,7 +107,7 @@ const SelectorInput = React.createClass({
       styles,
       top, // eslint-disable-line no-unused-vars
       value,
-      warning, // eslint-disable-line no-unused-vars
+      warning,
       ...props
     } = this.props
     const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
@@ -140,7 +117,7 @@ const SelectorInput = React.createClass({
 
     const dynamicStyles = useDynamicStyles
       ? {
-        borderColor: this.state.hover || focus
+        borderColor: this.state.hover
           ? customize.borderColorSelected
           : customize.borderColor
       }
@@ -164,7 +141,6 @@ const SelectorInput = React.createClass({
         square
       },
       fieldStates.getClassName(this.props),
-      programmaticFocus.getClassName(this.props),
       stacking.size.getClassName(this.props),
       stacking.position.getClassName(this.props),
       className
@@ -180,10 +156,6 @@ const SelectorInput = React.createClass({
       className: classNames(icon ? classes.iconInput : classes.input),
       disabled: disabled,
       id: ids.input,
-      onBlur: onBlur,
-      onChange: onChange,
-      onKeyDown: handleKeyDown(this.props),
-      onFocus: onFocus,
       ref: 'input',
       style: {
         ...inputDynamicStyles,

--- a/Selector/Input/styles.scss
+++ b/Selector/Input/styles.scss
@@ -276,8 +276,11 @@ $stackable-border-width: $grid * .2;
   height: ($grid * 10);
   line-height: ($grid * 10);
   outline: none;
-  padding: 0;
+  overflow: hidden;
+  padding-right: ($grid * 4);
   position: absolute;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   width: 100%;
 
   @include respond-to-wide {

--- a/Selector/Input/styles.scss
+++ b/Selector/Input/styles.scss
@@ -94,8 +94,8 @@ $stackable-border-width: $grid * .2;
   height: ($grid * 10);
   line-height: ($grid * 10);
   position: relative;
-  transition: border-color .2s ease;
   text-align: left;
+  transition: border-color .2s ease;
 
   &.big {
     height: ($grid * 12);

--- a/Selector/Input/styles.scss
+++ b/Selector/Input/styles.scss
@@ -83,7 +83,7 @@ $stackable-border-width: $grid * .2;
   }
 }
 
-%input {
+%selector-input {
   @include stackable-input();
 
   border-bottom: ($grid * .2) solid $border-color;
@@ -168,17 +168,17 @@ $stackable-border-width: $grid * .2;
   }
 
   &.is-centered {
-    .input__label {
+    .selector-input__label {
       padding: 0;
       width: 100%;
     }
 
-    .input--icon__input {
+    .selector-input--icon__input {
       padding: 0 40px;
     }
 
-    .input__input,
-    .input__label {
+    .selector-input__input,
+    .selector-input__label {
       text-align: center;
     }
   }
@@ -195,7 +195,7 @@ $stackable-border-width: $grid * .2;
   }
 }
 
-%input__label {
+%selector-input__label {
   @include typography(map-get($font-sizes, big-body-mobile), regular);
 
   color: map-get($colors, 'grey-text');
@@ -264,7 +264,7 @@ $stackable-border-width: $grid * .2;
   }
 }
 
-%input__input {
+%selector-input__input {
   @include typography(map-get($font-sizes, big-body-mobile), semi-bold);
 
   -webkit-tap-highlight-color: rgba(0,0,0,0);
@@ -287,8 +287,8 @@ $stackable-border-width: $grid * .2;
     @include typography(map-get($font-sizes, big-body-desktop), semi-bold);
   }
 
-  & .input__input-placeholder {
-    // This should be the same color and font weight as .input__label.
+  & .selector-input__input-placeholder {
+    // This should be the same color and font weight as .selector-input__label.
     color: map-get($colors, grey-text);
     font-weight: normal;
   }
@@ -342,32 +342,32 @@ $stackable-border-width: $grid * .2;
   }
 }
 
-.input {
-  @extend %input;
+.selector-input {
+  @extend %selector-input;
 }
 
-.input__label {
-  @extend %input__label;
+.selector-input__label {
+  @extend %selector-input__label;
 }
 
-.input__input {
-  @extend %input__input;
+.selector-input__input {
+  @extend %selector-input__input;
 }
 
-.input--icon {
-  @extend %input;
+.selector-input--icon {
+  @extend %selector-input;
 }
 
-.input--icon__label {
-  @extend %input__label;
+.selector-input--icon__label {
+  @extend %selector-input__label;
 }
 
-.input--icon__input {
-  @extend %input__input;
+.selector-input--icon__input {
+  @extend %selector-input__input;
 }
 
-.input--icon__label,
-.input--icon__input {
+.selector-input--icon__label,
+.selector-input--icon__input {
   padding-left: ($grid * 6);
 
   .giant & {
@@ -375,7 +375,7 @@ $stackable-border-width: $grid * .2;
   }
 }
 
-.input--icon__icon {
+.selector-input--icon__icon {
   display: block;
   fill-rule: evenodd;
   height: ($grid * 4);
@@ -397,23 +397,23 @@ $stackable-border-width: $grid * .2;
     @include illustration__fill(map-get($colors, grey-icon));
   }
 
-  .input--icon:hover &__fill {
+  .selector-input--icon:hover &__fill {
     @include illustration__fill(map-get($colors, blue-hover));
   }
 
-  .input--icon.is-focused &__fill {
+  .selector-input--icon.is-focused &__fill {
     @include illustration__fill(map-get($colors, blue-hover));
   }
 
-  .input--icon.is-error &__fill {
+  .selector-input--icon.is-error &__fill {
     @include illustration__fill(map-get($colors, red));
   }
 
-  .input--icon.is-warning &__fill {
+  .selector-input--icon.is-warning &__fill {
     @include illustration__fill(map-get($colors, warning-border));
   }
 
-  .input--icon.is-disabled &__fill {
+  .selector-input--icon.is-disabled &__fill {
     @include illustration__fill(map-get($colors, grey-lines));
   }
 
@@ -421,28 +421,28 @@ $stackable-border-width: $grid * .2;
     @include illustration__stroke(map-get($colors, grey-icon));
   }
 
-  .input--icon:hover &__stroke {
+  .selector-input--icon:hover &__stroke {
     @include illustration__stroke(map-get($colors, blue-hover));
   }
 
-  .input--icon.is-focused &__stroke {
+  .selector-input--icon.is-focused &__stroke {
     @include illustration__stroke(map-get($colors, blue-hover));
   }
 
-  .input--icon.is-error &__stroke {
+  .selector-input--icon.is-error &__stroke {
     @include illustration__stroke(map-get($colors, red));
   }
 
-  .input--icon.is-warning &__stroke {
+  .selector-input--icon.is-warning &__stroke {
     @include illustration__stroke(map-get($colors, warning-border));
   }
 
-  .input--icon.is-disabled &__stroke {
+  .selector-input--icon.is-disabled &__stroke {
     @include illustration__stroke(map-get($colors, grey-lines));
   }
 }
 
-.input--icon__placeholder {
+.selector-input--icon__placeholder {
   background: map-get($colors, grey-lines);
   display: block;
   height: ($grid * 4);
@@ -461,10 +461,11 @@ $stackable-border-width: $grid * .2;
   }
 }
 
-.input__link-wrapper {
+.selector-input__link-wrapper {
   line-height: ($grid * 4);
   margin-top: ($grid * -2);
   position: absolute;
   right: 0;
   top: 50%;
 }
+

--- a/Selector/Input/styles.scss
+++ b/Selector/Input/styles.scss
@@ -94,6 +94,7 @@ $stackable-border-width: $grid * .2;
   height: ($grid * 10);
   line-height: ($grid * 10);
   position: relative;
+  transition: border-color .2s ease;
   text-align: left;
 
   &.big {

--- a/Selector/Input/styles.scss
+++ b/Selector/Input/styles.scss
@@ -1,0 +1,466 @@
+@import '../../css/settings';
+@import '../../css/mixins/index';
+
+$stackable-border-width: $grid * .2;
+
+@mixin partial-width-input ($width) {
+  @include respond-to-wide {
+    @include partial-width(calc(#{$width} - 12.5px));
+  }
+
+  &.center {
+    @include respond-to-wide {
+      @include partial-width(calc(#{$width} - 25px));
+    }
+  }
+}
+
+@mixin stackable-input () {
+  &.eighty {
+    @include partial-width-input(80%);
+  }
+
+  &.three-quarters {
+    @include partial-width-input(75%);
+  }
+
+  &.two-thirds {
+    @include partial-width-input(66.66666%);
+  }
+
+  &.sixty {
+    @include partial-width-input(60%);
+  }
+
+  &.half {
+    @include partial-width-input(50%);
+  }
+
+  &.forty {
+    @include partial-width-input(40%);
+  }
+
+  &.third {
+    @include partial-width-input(33.33333%);
+  }
+
+  &.quarter {
+    @include partial-width-input(25%);
+  }
+
+  &.twenty {
+    @include partial-width-input(20%);
+  }
+
+  &.left {
+    @include respond-to-wide {
+      margin-right: 12.5px;
+    }
+  }
+
+  &.center {
+    @include respond-to-wide {
+      margin: 0 12.5px;
+    }
+
+    &::after {
+      clear: both;
+      content: '';
+      display: block;
+    }
+  }
+
+  &.right {
+    @include respond-to-wide {
+      margin-left: 12.5px;
+    }
+
+    &::after {
+      clear: both;
+      content: '';
+      display: block;
+    }
+  }
+}
+
+%input {
+  @include stackable-input();
+
+  border-bottom: ($grid * .2) solid $border-color;
+  box-sizing: border-box;
+  clear: both;
+  cursor: pointer;
+  display: block;
+  height: ($grid * 10);
+  line-height: ($grid * 10);
+  position: relative;
+  text-align: left;
+
+  &.big {
+    height: ($grid * 12);
+    line-height: ($grid * 12);
+  }
+
+  &.giant {
+    height: ($grid * 16);
+    line-height: ($grid * 16);
+  }
+
+  &.is-hidden {
+    display: none;
+  }
+
+  &:focus {
+    border-bottom-width: ($grid * .4);
+    outline: none;
+  }
+
+  &:hover {
+    border-color: map-get($colors, blue-hover);
+    z-index: 10;
+  }
+
+  &.is-focused {
+    border-bottom-width: ($grid * .4);
+    border-color: map-get($colors, blue-focus);
+    z-index: 20;
+  }
+
+  &.is-error {
+    border-color: map-get($colors, error-border);
+    box-shadow: none;
+    z-index: 5;
+
+    &:hover {
+      border-color: map-get($colors, error-hover);
+      z-index: 10;
+    }
+
+    &.is-focused {
+      border-color: map-get($colors, error);
+      z-index: 20;
+    }
+  }
+
+  &.is-warning {
+    border-color: map-get($colors, warning-border);
+    box-shadow: none;
+    z-index: 5;
+
+    &:hover {
+      border-color: map-get($colors, warning-hover);
+      z-index: 10;
+    }
+
+    &.is-focused {
+      border-color: map-get($colors, warning-hover);
+      z-index: 20;
+    }
+  }
+
+  &.is-disabled {
+    border-color: map-get($colors, grey-lines);
+
+    &:hover {
+      border-color: map-get($colors, grey-lines);
+    }
+  }
+
+  &.is-centered {
+    .input__label {
+      padding: 0;
+      width: 100%;
+    }
+
+    .input--icon__input {
+      padding: 0 40px;
+    }
+
+    .input__input,
+    .input__label {
+      text-align: center;
+    }
+  }
+
+  &.is-loading {
+    &:after {
+      @include button__loader;
+      content: '';
+      margin-top: -10px;
+      position: absolute;
+      right: 15px;
+      top: 50%;
+    }
+  }
+}
+
+%input__label {
+  @include typography(map-get($font-sizes, big-body-mobile), regular);
+
+  color: map-get($colors, 'grey-text');
+  line-height: ($grid * 10);
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  text-overflow: ellipsis;
+  transition: transform .2s ease, font-size .2s ease, color .2s ease;
+  white-space: nowrap;
+  width: 100%;
+
+  @include respond-to-wide {
+    @include typography(map-get($font-sizes, big-body-desktop), regular);
+  }
+
+  .big & {
+    height: ($grid * 12);
+    line-height: ($grid * 13);
+  }
+
+  .giant & {
+    @include typography(map-get($font-sizes, giant-input), light);
+    line-height: ($grid * 16);
+    transform: translate(0, ($grid * 2));
+  }
+
+  .big.is-filled &,
+  .big.is-error &,
+  .big.is-warning & {
+    transform: translate(0, ($grid * -2.2));
+  }
+
+  .giant.is-filled &,
+  .giant.is-error &,
+  .giant.is-warning & {
+    transform: translate(0, ($grid * -3.8));
+  }
+
+  .is-filled &,
+  .is-error &,
+  .is-warning & {
+    @include typography(map-get($font-sizes, input-label), regular);
+
+    transform: translate(0, ($grid * -2));
+  }
+
+  .is-filled & {
+    color: map-get($colors, 'grey-text');
+  }
+
+  .is-error & {
+    color: map-get($colors, error);
+  }
+
+  .is-warning & {
+    color: map-get($colors, warning);
+  }
+
+  .is-disabled & {
+    color: map-get($colors, grey-lines);
+  }
+
+  .ie9 & {
+    z-index: 1;
+  }
+}
+
+%input__input {
+  @include typography(map-get($font-sizes, big-body-mobile), semi-bold);
+
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+  appearance: none;
+  background-color: transparent;
+  border: 0;
+  box-sizing: border-box;
+  color: map-get($colors, black);
+  height: ($grid * 10);
+  line-height: ($grid * 10);
+  outline: none;
+  padding: 0;
+  position: absolute;
+  width: 100%;
+
+  @include respond-to-wide {
+    @include typography(map-get($font-sizes, big-body-desktop), semi-bold);
+  }
+
+  & .input__input-placeholder {
+    // This should be the same color and font weight as .input__label.
+    color: map-get($colors, grey-text);
+    font-weight: normal;
+  }
+
+  .big & {
+    height: ($grid * 13);
+    line-height: ($grid * 13);
+  }
+
+  .giant & {
+    @include typography(map-get($font-sizes, giant-input), light);
+    height: ($grid * 16);
+    line-height: ($grid * 16);
+    top: ($grid * 2);
+  }
+
+  .is-filled &,
+  .is-error &,
+  .is-warning & {
+    height: ($grid * 9);
+    line-height: ($grid * 9);
+    top: ($grid * 1.6);
+  }
+
+  .big.is-filled &,
+  .big.is-error &,
+  .big.is-warning & {
+    height: ($grid * 9.8);
+    line-height: ($grid * 9.8);
+    top: ($grid * 2.2);
+  }
+
+  .giant.is-filled &,
+  .giant.is-error &,
+  .giant.is-warning & {
+    height: ($grid * 16);
+    line-height: ($grid * 16);
+    top: ($grid * 2);
+  }
+
+  .is-disabled & {
+    color: map-get($colors, grey-lines);
+    /* Override webkit font color change */
+    -webkit-text-fill-color: map-get($colors, grey-lines);
+    -webkit-opacity: 1;
+  }
+
+  .safari &,
+  .ios & {
+    -webkit-transform: translate3d(0, 0, 0);
+  }
+}
+
+.input {
+  @extend %input;
+}
+
+.input__label {
+  @extend %input__label;
+}
+
+.input__input {
+  @extend %input__input;
+}
+
+.input--icon {
+  @extend %input;
+}
+
+.input--icon__label {
+  @extend %input__label;
+}
+
+.input--icon__input {
+  @extend %input__input;
+}
+
+.input--icon__label,
+.input--icon__input {
+  padding-left: ($grid * 6);
+
+  .giant & {
+    padding-left: ($grid * 7);
+  }
+}
+
+.input--icon__icon {
+  display: block;
+  fill-rule: evenodd;
+  height: ($grid * 4);
+  margin: ($grid * 3) 0 0 0;
+  position: absolute;
+  width: ($grid * 4);
+
+  .big & {
+    margin-top: ($grid * 4);
+  }
+
+  .giant & {
+    height: ($grid * 5);
+    margin: ($grid * 7.6) 0 0;
+    width: ($grid * 5);
+  }
+
+  &__fill {
+    @include illustration__fill(map-get($colors, grey-icon));
+  }
+
+  .input--icon:hover &__fill {
+    @include illustration__fill(map-get($colors, blue-hover));
+  }
+
+  .input--icon.is-focused &__fill {
+    @include illustration__fill(map-get($colors, blue-hover));
+  }
+
+  .input--icon.is-error &__fill {
+    @include illustration__fill(map-get($colors, red));
+  }
+
+  .input--icon.is-warning &__fill {
+    @include illustration__fill(map-get($colors, warning-border));
+  }
+
+  .input--icon.is-disabled &__fill {
+    @include illustration__fill(map-get($colors, grey-lines));
+  }
+
+  &__stroke {
+    @include illustration__stroke(map-get($colors, grey-icon));
+  }
+
+  .input--icon:hover &__stroke {
+    @include illustration__stroke(map-get($colors, blue-hover));
+  }
+
+  .input--icon.is-focused &__stroke {
+    @include illustration__stroke(map-get($colors, blue-hover));
+  }
+
+  .input--icon.is-error &__stroke {
+    @include illustration__stroke(map-get($colors, red));
+  }
+
+  .input--icon.is-warning &__stroke {
+    @include illustration__stroke(map-get($colors, warning-border));
+  }
+
+  .input--icon.is-disabled &__stroke {
+    @include illustration__stroke(map-get($colors, grey-lines));
+  }
+}
+
+.input--icon__placeholder {
+  background: map-get($colors, grey-lines);
+  display: block;
+  height: ($grid * 4);
+  width: ($grid * 4);
+
+  .is-focused & {
+    background: map-get($colors, klarna-blue);
+  }
+
+  .is-error & {
+    background: map-get($colors, error-border);
+  }
+
+  .is-warning & {
+    background: map-get($colors, warning-border);
+  }
+}
+
+.input__link-wrapper {
+  line-height: ($grid * 4);
+  margin-top: ($grid * -2);
+  position: absolute;
+  right: 0;
+  top: 50%;
+}

--- a/Selector/example.jsx
+++ b/Selector/example.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import * as Selector from '../Selector'
+import Input from '../Input'
 import UncontrolledSelector from '../uncontrolled/Selector'
 import { LIVE } from '../Showroom/variationTypes'
 
@@ -18,6 +19,54 @@ export default {
   icon: 'Baseline',
 
   variations: [
+    {
+      title: 'Selector Input',
+      require: 'import * as Selector from \'@klarna/ui/Selector\'',
+      type: LIVE,
+
+      examples: {
+        Regular: <Selector.Input
+          onClick={(e) => { console.info('it was clicked', e)}}
+          label='Organization type'
+        />,
+        RegularValue: <Selector.Input
+          onClick={(e) => { console.info('it was clicked', e)}}
+          label='Organization type'
+          value='This is the value'
+        />,
+        Big: <Selector.Input label='Organization type' big />,
+        BigValue: <Selector.Input label='Organization type' big value='This is the value' />,
+        Giant: <Selector.Input label='Organization type' giant />,
+        GiantValue: <Selector.Input label='Organization type' giant value='This is the value' />,
+        Focused: <Selector.Input label='Organization type' focus />,
+        'Fake focused': <Selector.Input label='Organization type' focus='fake' />,
+        Disabled: <Selector.Input disabled label='Address' />,
+        DisabledValue: <Selector.Input disabled label='Address' value='16, Corn street' />,
+        'Exclude Mouseflow': <Selector.Input
+          mouseflowExclude
+          label='Address'
+          value='16, Corn street'
+        />,
+        'With error': <Selector.Input label='Please select an Organization type' placeholder='Organization type' error />,
+        'With warning': <Selector.Input
+          label='Please select another Organization type'
+          warning
+          value='This is the wrong type?'
+        />,
+        'Normal Input': <Input
+          onChange={(v) => v}
+          label='Organization type'
+          value='This is the value'
+        />,
+        'Normal Input error': <Input
+          onChange={(v) => v}
+          error
+          label='Please enter Organization type'
+          placeholder='Foobar'
+        />
+      }
+    },
+
     {
       title: 'Options Selector',
       require: `import * as Selector from '@klarna/ui/Selector'

--- a/Selector/example.jsx
+++ b/Selector/example.jsx
@@ -68,7 +68,7 @@ import * as Selector from '@klarna/ui/Selector'`,
       examples: {
         Variations: <Fieldset margins>
           <Selector.Input
-            onClick={(e) => { console.info('it was clicked', e) }}
+            onClick={(e) => console.info('it was clicked', e)}
             link='Select'
             label='Organization type'
           />

--- a/Selector/example.jsx
+++ b/Selector/example.jsx
@@ -69,25 +69,30 @@ import * as Selector from '@klarna/ui/Selector'`,
         Variations: <Fieldset margins>
           <Selector.Input
             onClick={(e) => { console.info('it was clicked', e) }}
+            link='Select'
             label='Organization type'
           />
           <Selector.Input
             label='Organization type'
+            link='Select'
             value='Standard Organization'
           />
           <Selector.Input
             error
             label='Please select an organization type'
+            link='Select'
             placeholder='Organization type'
           />
           <Selector.Input
             icon={icons.BANK}
             label='Organization type'
+            link='Select'
           />
           <Selector.Input
             icon={icons.BANK}
             error
             label='Please select an organization type'
+            link='Select'
             placeholder='Organization type'
           />
         </Fieldset>

--- a/Selector/example.jsx
+++ b/Selector/example.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import * as Selector from '../Selector'
-import Input from '../Input'
+import Input, { icons } from '../Input'
+import Fieldset from '../Fieldset'
 import UncontrolledSelector from '../uncontrolled/Selector'
 import { LIVE } from '../Showroom/variationTypes'
 
@@ -19,54 +20,6 @@ export default {
   icon: 'Baseline',
 
   variations: [
-    {
-      title: 'Selector Input',
-      require: 'import * as Selector from \'@klarna/ui/Selector\'',
-      type: LIVE,
-
-      examples: {
-        Regular: <Selector.Input
-          onClick={(e) => { console.info('it was clicked', e)}}
-          label='Organization type'
-        />,
-        RegularValue: <Selector.Input
-          onClick={(e) => { console.info('it was clicked', e)}}
-          label='Organization type'
-          value='This is the value'
-        />,
-        Big: <Selector.Input label='Organization type' big />,
-        BigValue: <Selector.Input label='Organization type' big value='This is the value' />,
-        Giant: <Selector.Input label='Organization type' giant />,
-        GiantValue: <Selector.Input label='Organization type' giant value='This is the value' />,
-        Focused: <Selector.Input label='Organization type' focus />,
-        'Fake focused': <Selector.Input label='Organization type' focus='fake' />,
-        Disabled: <Selector.Input disabled label='Address' />,
-        DisabledValue: <Selector.Input disabled label='Address' value='16, Corn street' />,
-        'Exclude Mouseflow': <Selector.Input
-          mouseflowExclude
-          label='Address'
-          value='16, Corn street'
-        />,
-        'With error': <Selector.Input label='Please select an Organization type' placeholder='Organization type' error />,
-        'With warning': <Selector.Input
-          label='Please select another Organization type'
-          warning
-          value='This is the wrong type?'
-        />,
-        'Normal Input': <Input
-          onChange={(v) => v}
-          label='Organization type'
-          value='This is the value'
-        />,
-        'Normal Input error': <Input
-          onChange={(v) => v}
-          error
-          label='Please enter Organization type'
-          placeholder='Foobar'
-        />
-      }
-    },
-
     {
       title: 'Options Selector',
       require: `import * as Selector from '@klarna/ui/Selector'
@@ -103,6 +56,41 @@ import UncontrolledSelector from '@klarna/ui/uncontrolled/Selector'`,
           data={directData}
           onSelect={(v) => (v)}
         />
+      }
+    },
+
+    {
+      title: 'Selector Input',
+      require: `import Fieldset from '@klarna/ui/Fieldset'
+import * as Selector from '@klarna/ui/Selector'`,
+      type: LIVE,
+
+      examples: {
+        Variations: <Fieldset margins>
+          <Selector.Input
+            onClick={(e) => { console.info('it was clicked', e) }}
+            label='Organization type'
+          />
+          <Selector.Input
+            label='Organization type'
+            value='Standard Organization'
+          />
+          <Selector.Input
+            error
+            label='Please select an organization type'
+            placeholder='Organization type'
+          />
+          <Selector.Input
+            icon={icons.BANK}
+            label='Organization type'
+          />
+          <Selector.Input
+            icon={icons.BANK}
+            error
+            label='Please select an organization type'
+            placeholder='Organization type'
+          />
+        </Fieldset>
       }
     }
   ]

--- a/Selector/index.jsx
+++ b/Selector/index.jsx
@@ -1,2 +1,3 @@
 export { default as Options } from './Options'
 export { default as Direct } from './Direct'
+export { default as Input } from './Input'

--- a/Theme/example.jsx
+++ b/Theme/example.jsx
@@ -12,6 +12,7 @@ import * as Title from '../Title'
 import Radio from '../Radio'
 import Subtitle from '../Subtitle'
 import * as Paragraph from '../Paragraph'
+import * as Selector from '../Selector'
 import * as List from '../List'
 import { Back, Hamburger } from '../IconButton'
 import { LIVE } from '../Showroom/variationTypes'
@@ -296,6 +297,19 @@ import * as List from '@klarna/ui/List'`,
             forfuraj ratjoj vaŭis.
           </List.Item>
         </List.Ordered>
+
+        <Selector.Input
+          label='Organization type'
+        />
+        <Selector.Input
+          label='Please select an organization type'
+          placeholder='Organization type'
+          error
+        />
+        <Selector.Input
+          label='Organization type'
+          value='This is the value'
+        />
       </Theme>
     }
   }

--- a/Theme/example.jsx
+++ b/Theme/example.jsx
@@ -300,14 +300,17 @@ import * as List from '@klarna/ui/List'`,
 
         <Selector.Input
           label='Organization type'
+          link='Select'
         />
         <Selector.Input
           label='Please select an organization type'
           placeholder='Organization type'
+          link='Select'
           error
         />
         <Selector.Input
           label='Organization type'
+          link='Select'
           value='This is the value'
         />
       </Theme>


### PR DESCRIPTION
This is a new component. Its purpose is to:
- Look and behave much like an `<Input>`, but without the editable "input" field
- Show that a value can be "selected", and
- Show the "selected" value if there is one.

The selection itself is _not_ connected to the component. Here's a concept where the fullscreen dialog transitions to a `Selector.Options` component to do the selection:

![selector concept](https://cloud.githubusercontent.com/assets/569742/22145378/607802ac-df01-11e6-9f94-5da8872ffa73.png)

This has been pretty much a copy-paste from `<Input>`, which means that it has support for modes like `big`, `giant`, `icon` etc., it's stackable inside fieldsets, and so on. All variations haven't been confirmed or optimized, since it's not going to be needed right now. I left it in there anyway so it would be easy to fine-tune it when needed. It also supports dynamic/merchant/themeable styling, which is a requirement.

While it works, it's a bit crude, so I'll see if I can clean it up a bit. There's likely some stuff from Input still in there that is not needed.