### PR TITLE
Add example and increase border radius

### DIFF
--- a/Button/example.jsx
+++ b/Button/example.jsx
@@ -141,9 +141,16 @@ export default {
           Pay now!
           <Button.Price>14:-</Button.Price>
         </Button.Primary>,
-        'High brand volume': <Button.Primary brandVolume='high'>
-          Start your journey
-        </Button.Primary>,
+        'High brand volume': (
+          <div>
+            <Button.Primary brandVolume='high'>
+              Start your journey
+            </Button.Primary>
+            <Button.Primary brandVolume='high' size='big' style={{marginTop: 10}}>
+              Start your journey
+            </Button.Primary>
+          </div>
+        ),
         Disabled: <Button.Primary disabled>Click me!</Button.Primary>,
         Loading: <Button.Primary loading>Click me!</Button.Primary>,
         'Loading with customization': <Button.Primary
@@ -167,9 +174,16 @@ export default {
           customize={{textColor: '#F9FF3C', borderRadius: '15px', backgroundColor: '#3500C8'}}>
           Beautiful!
         </Button.Secondary>,
-        'High brand volume': <Button.Secondary brandVolume='high'>
-          Start your journey
-        </Button.Secondary>,
+        'High brand volume': (
+          <div>
+            <Button.Secondary brandVolume='high'>
+              Start your journey
+            </Button.Secondary>
+            <Button.Secondary brandVolume='high' size='big' style={{marginTop: 10}}>
+              Start your journey
+            </Button.Secondary>
+          </div>
+        ),
         Disabled: <Button.Secondary disabled>Click me!</Button.Secondary>,
         Loading: <Button.Secondary loading>Click me!</Button.Secondary>,
         'Loading with customization': <Button.Secondary

--- a/Button/styles.scss
+++ b/Button/styles.scss
@@ -30,7 +30,7 @@
   }
 
   &.brand-volume-high {
-    border-radius: ($grid * 5);
+    border-radius: ($grid * 6);
   }
 
   &:hover {
@@ -100,7 +100,7 @@
   }
 
   &.brand-volume-high {
-    border-radius: ($grid * 5);
+    border-radius: ($grid * 6);
   }
 
   &:hover {


### PR DESCRIPTION
Add support for __big__ brand volume buttons
![screen shot 2017-01-23 at 14 10 25](https://cloud.githubusercontent.com/assets/8209700/22203447/d1132af2-e175-11e6-8931-2b556ab1117c.png)
![screen shot 2017-01-23 at 14 10 58](https://cloud.githubusercontent.com/assets/8209700/22203448/d1137a16-e175-11e6-8897-76d4068b7076.png)
