### PR TITLE
Make Selector.Options themeable

### DIFF
--- a/Selector/Input/index.jsx
+++ b/Selector/Input/index.jsx
@@ -221,4 +221,3 @@ export default compose(
   })),
   overridable(defaultStyles)
 )(SelectorInput)
-

--- a/Selector/Options/index.jsx
+++ b/Selector/Options/index.jsx
@@ -25,7 +25,7 @@ const Options = React.createClass({
       borderColor: PropTypes.string.isRequired,
       bulletColor: PropTypes.string.isRequired,
       labelColor: PropTypes.string.isRequired,
-      labelColorSelected: PropTypes.string.isRequired,
+      labelColorSelected: PropTypes.string.isRequired
     }),
     data: PropTypes.array.isRequired,
     focus: PropTypes.any,
@@ -157,7 +157,7 @@ const Options = React.createClass({
 
   onOptionMouseLeave (key) {
     this.setState({ hover: undefined })
-  },
+  }
 })
 
 export default compose(

--- a/Selector/Options/index.jsx
+++ b/Selector/Options/index.jsx
@@ -1,8 +1,11 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
+import compose from '../../lib/compose'
 import defaultStyles from './styles.scss'
 import Checkmark from '../../icons/Checkmark'
 import getActiveElement from '../../lib/getActiveElement'
+import themeable from '../../decorators/themeable'
+import overridable from '../../decorators/overridable'
 
 const baseClass = 'selector--options'
 
@@ -13,11 +16,17 @@ const classes = {
   label: `${baseClass}__label`
 }
 
-export default React.createClass({
+const Options = React.createClass({
   displayName: 'Selector.Options',
 
   propTypes: {
     className: PropTypes.string,
+    customize: PropTypes.shape({
+      borderColor: PropTypes.string.isRequired,
+      bulletColor: PropTypes.string.isRequired,
+      labelColor: PropTypes.string.isRequired,
+      labelColorSelected: PropTypes.string.isRequired,
+    }),
     data: PropTypes.array.isRequired,
     focus: PropTypes.any,
     id: PropTypes.string,
@@ -28,6 +37,13 @@ export default React.createClass({
     styles: PropTypes.object,
     // Allows any type to be a key, as long as it is comparable
     value: PropTypes.any
+  },
+
+  getInitialState () {
+    return {
+      hover: undefined,
+      focus: undefined
+    }
   },
 
   componentDidMount () {
@@ -51,6 +67,7 @@ export default React.createClass({
   render () {
     const {
       className,
+      customize,
       data,
       focus,
       name,
@@ -63,6 +80,7 @@ export default React.createClass({
     } = this.props
 
     const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+    const useDynamicStyles = !!customize
 
     return (
       <div
@@ -70,12 +88,23 @@ export default React.createClass({
         id={name}
         {...remainingProps}>
         {data.map(({key, label}) => {
+          const isFocused = focus === key
+          const isHovered = this.state.hover === key
+          const isSelected = value === key
           const id = `${name}-${key}`
           const ids = {
             icon: `${id}__icon`,
             label: `${id}__label`,
             labelInner: `${id}__label--inner`
           }
+
+          const itemDynamicStyles = useDynamicStyles
+            ? { borderColor: customize.borderColor }
+            : undefined
+
+          const labelDynamicStyles = useDynamicStyles
+            ? { color: (isHovered || isSelected) ? customize.labelColorSelected : customize.labelColor }
+            : undefined
 
           return [
             <input
@@ -93,21 +122,26 @@ export default React.createClass({
             <label
               htmlFor={id}
               className={classNames(
-                classes.item, {'is-focused': focus === key}
+                classes.item, {'is-focused': isFocused}
               )}
               id={ids.label}
-              key={key}>
+              key={key}
+              onMouseEnter={this.onOptionMouseEnter.bind(this, key)}
+              onMouseLeave={this.onOptionMouseLeave.bind(this, key)}
+              style={itemDynamicStyles}>
               <div
                 className={classNames(classes.label)}
-                id={ids.labelInner}>
+                id={ids.labelInner}
+                style={labelDynamicStyles}>
                 {label}
               </div>
 
-              {key === value && (
+              {isSelected && (
                 <Checkmark
                   className={classNames(classes.icon)}
                   color='blue'
                   id={ids.icon}
+                  stroke={useDynamicStyles && customize.bulletColor}
                 />
               )}
             </label>
@@ -115,5 +149,26 @@ export default React.createClass({
         })}
       </div>
     )
-  }
+  },
+
+  onOptionMouseEnter (key) {
+    this.setState({ hover: key })
+  },
+
+  onOptionMouseLeave (key) {
+    this.setState({ hover: undefined })
+  },
 })
+
+export default compose(
+  themeable((customizations, props) => ({
+    customize: {
+      ...props.customize,
+      borderColor: customizations.color_border,
+      bulletColor: customizations.color_checkbox_checkmark,
+      labelColor: customizations.color_text_secondary,
+      labelColorSelected: customizations.color_text
+    }
+  })),
+  overridable(defaultStyles)
+)(Options)

--- a/Theme/example.jsx
+++ b/Theme/example.jsx
@@ -319,6 +319,10 @@ import * as List from '@klarna/ui/List'`,
           link='Select'
           value='This is the value'
         />
+        <Selector.Options
+          data={options}
+          value={2}
+        />
       </Theme>
     }
   }

--- a/icons/Checkmark.jsx
+++ b/icons/Checkmark.jsx
@@ -3,7 +3,7 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
 import colors from './constants/colors'
 
-export default function Checkmark ({ color, styles, className, ...props }) {
+export default function Checkmark ({ color, styles, className, stroke, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
@@ -17,7 +17,8 @@ export default function Checkmark ({ color, styles, className, ...props }) {
       {...props}>
       <path
         d='M5 13.69l4.49 4.23L19.37 8'
-        className={classNames('illustration__stroke')} />
+        className={classNames('illustration__stroke')}
+        style={stroke ? {stroke} : undefined}/>
     </svg>
   )
 }


### PR DESCRIPTION
Makes the `Selector.Options` component themeable. Here it is in all its colorful glory:

![options-selector](https://cloud.githubusercontent.com/assets/569742/22214501/11657a48-e198-11e6-9e32-55968767d061.gif)

And for reference, here's the default look:

![options-selector-default](https://cloud.githubusercontent.com/assets/569742/22214459/f1e6dcf2-e197-11e6-894f-e55f7a8a3910.gif)

