### PR TITLE
Fix the installments broken layout 

### DIFF
--- a/Installments/index.jsx
+++ b/Installments/index.jsx
@@ -33,7 +33,8 @@ class Installments extends Component {
 
       case 'auto':
       default:
-        const wide = window.innerWidth > MOBILE_MAX_WIDTH
+        const currentWidth = window.innerWidth || document.body.clientWidth
+        const wide = currentWidth >= MOBILE_MAX_WIDTH
 
         return <div
           className={classNames(baseClass)}


### PR DESCRIPTION
The installments component in auto mode should change it orientation (vertical or horizontal) depending on the size of the screen. If we decrease the screen size to have the vertical installments active and we start to slowly increase the width, when we come closely to the width break point the layout of the component breaks and stays like that until we interact with it.
The broken layout is displayed all the time for devices with screen sizes in the "breaking range", or if we load the component in a dialog.

![screen shot 2017-01-25 at 13 30 34](https://cloud.githubusercontent.com/assets/2915276/22295068/e478f490-e315-11e6-8eac-157984de1af5.png)


On some IE versions the component is broken because the window.innerWidth property is missing. That's why I fallback to document.body.clientWidth if it does not exist.