### PR TITLE
Fix disabled state of the SelectorInput component

### DIFF
--- a/Selector/Input/index.jsx
+++ b/Selector/Input/index.jsx
@@ -178,10 +178,11 @@ const SelectorInput = React.createClass({
       <div
         className={cls}
         id={id}
-        onClick={onClick}
+        onClick={(e) => !disabled && onClick && onClick(e)}
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
         style={dynamicStyles}>
+
         {
           inlinedIcon.renderInlinedIcon(this.props, {
             icon: classNames(classes.iconIcon),
@@ -201,9 +202,12 @@ const SelectorInput = React.createClass({
           ? <MouseflowExclude>{inputElement}</MouseflowExclude>
           : inputElement
         }
-        <div className={classNames(classes.linkWrapper)}>
-          <Select label={link} />
-        </div>
+
+        {!disabled && (
+          <div className={classNames(classes.linkWrapper)}>
+            <Select label={link} />
+          </div>
+        )}
       </div>
     )
   }

--- a/Selector/Input/styles.scss
+++ b/Selector/Input/styles.scss
@@ -161,6 +161,7 @@ $stackable-border-width: $grid * .2;
 
   &.is-disabled {
     border-color: map-get($colors, grey-lines);
+    cursor: default;
 
     &:hover {
       border-color: map-get($colors, grey-lines);

--- a/Selector/example.jsx
+++ b/Selector/example.jsx
@@ -73,9 +73,11 @@ import * as Selector from '@klarna/ui/Selector'`,
             label='Organization type'
           />
           <Selector.Input
+            onClick={(e) => console.info('click event disabled', e)}
             label='Organization type'
             link='Select'
             value='Standard Organization'
+            disabled
           />
           <Selector.Input
             error


### PR DESCRIPTION
Fixes a few details in the disabled state of the SelectorInput component:

- Cursor should not be 'pointer'
- The link should be hidden
- The onClick handler should not fire when clicked

Regular vs disabled:

<img width="291" alt="disabled-state" src="https://cloud.githubusercontent.com/assets/569742/22295173/4331886c-e316-11e6-81ac-9ce69b8d6b7c.png">
