### PR TITLE
Remove the highlighted text on themeable selected option

### DIFF
--- a/Selector/Options/index.jsx
+++ b/Selector/Options/index.jsx
@@ -103,7 +103,7 @@ const Options = React.createClass({
             : undefined
 
           const labelDynamicStyles = useDynamicStyles
-            ? { color: (isHovered || isSelected) ? customize.labelColorSelected : customize.labelColor }
+            ? { color: isHovered ? customize.labelColorSelected : customize.labelColor }
             : undefined
 
           return [


### PR DESCRIPTION
This is to make the themeable version of the component behave like the default version, as per #280 