### PR TITLE
Calculate border-radii for all variations of stacked fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 npm-debug.log
+yarn-error.log
 .idea/
 *.woff
 *.eot

--- a/Theme/example.jsx
+++ b/Theme/example.jsx
@@ -200,9 +200,11 @@ import * as List from '@klarna/ui/List'`,
         </Fieldset>
 
         <Fieldset margins>
-          <Field top label='Address' value='16, Corn street' focus='fake' />
+          <Dropdown top left size='1/2' label='Title' options={options} value={1} />
+          <Field top right size='1/2' label='Address' value='16, Corn street' />
           <Field square label='Given name' />
-          <Field bottom error label='Family name' />
+          <Field bottom left size='1/2' error label='Family name' />
+          <Dropdown bottom right size='1/2' label='Middle name' options={options} focus='fake' />
         </Fieldset>
 
         <div style={{paddingBottom: '20px'}}>

--- a/lib/features/stacking/index.js
+++ b/lib/features/stacking/index.js
@@ -2,9 +2,6 @@ import { PropTypes } from 'react'
 import combinations from '../../../lib/combinations'
 import fieldSizeFraction from '../../../propTypes/fieldSizeFraction'
 
-function borderRadii ({ top, bottom, left, right, square }, radius) {
-}
-
 export const position = {
   defaultProps: {
     bottom: false,

--- a/lib/features/stacking/index.js
+++ b/lib/features/stacking/index.js
@@ -2,6 +2,9 @@ import { PropTypes } from 'react'
 import combinations from '../../../lib/combinations'
 import fieldSizeFraction from '../../../propTypes/fieldSizeFraction'
 
+function borderRadii ({ top, bottom, left, right, square }, radius) {
+}
+
 export const position = {
   defaultProps: {
     bottom: false,
@@ -21,29 +24,20 @@ export const position = {
         ) || []
     ).join('-'),
 
-  getBorderRadii: ({ top, bottom, square }, radius) => (
-    top
-      ? {
-        borderBottomLeftRadius: '0px',
-        borderBottomRightRadius: '0px',
-        borderTopLeftRadius: radius,
-        borderTopRightRadius: radius
-      }
-      : bottom
-        ? {
-          borderBottomLeftRadius: radius,
-          borderBottomRightRadius: radius,
-          borderTopLeftRadius: '0px',
-          borderTopRightRadius: '0px'
-        }
-        : square
-          ? {
-            borderRadius: '0px'
-          }
-          : {
-            borderRadius: radius
-          }
-  ),
+  getBorderRadii: ({ top, bottom, left, right, square }, radius) => {
+    const rules = [
+      { condition: square, style: { borderRadius: '0px' } },
+      { condition: top && !left && !right, style: { borderRadius: `${radius} ${radius} 0px 0px` } },
+      { condition: top && left && !right, style: { borderRadius: `${radius} 0px 0px 0px` } },
+      { condition: top && !left && right, style: { borderRadius: `0px ${radius} 0px 0px` } },
+      { condition: bottom && !left && !right, style: { borderRadius: `0px 0px ${radius} ${radius}` } },
+      { condition: bottom && left && !right, style: { borderRadius: `0px 0px 0px ${radius}` } },
+      { condition: bottom && !left && right, style: { borderRadius: `0px 0px ${radius} 0px` } },
+      { condition: true, style: { borderRadius: radius } } // default fall-through value
+    ]
+
+    return rules.find(({ condition }) => condition).style
+  },
 
   positionCombinations: combinations(
     ['bottom', 'top'],


### PR DESCRIPTION
The existing implementation only concerned top-, bottom-, and square fields. This adds support for left- and right variations as well.

<img width="415" alt="border-radii" src="https://cloud.githubusercontent.com/assets/569742/22367895/3105d2aa-e484-11e6-8fe7-0520ddb2535b.png">
