### PR TITLE
Fix empty mouseflow nodes

### DIFF
--- a/MouseflowExclude/index.jsx
+++ b/MouseflowExclude/index.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 
 const NODE_COMMENT = 8
+const COMMENT_START = 'MouseflowExcludeStart'
+const COMMENT_END = 'MouseflowExcludeEnd'
 
 const MouseflowExclude = React.createClass({
   displayName: 'MouseflowExclude',
@@ -14,16 +16,12 @@ const MouseflowExclude = React.createClass({
           return
         }
 
-        if (firstChild.nodeType === NODE_COMMENT && firstChild.textContent === 'MouseflowExcludeStart') {
+        if (firstChild.nodeType === NODE_COMMENT && firstChild.textContent === COMMENT_START) {
           return
         }
 
-        span.insertBefore(
-          document.createComment('MouseflowExcludeStart'),
-          firstChild
-        )
-
-        span.appendChild(document.createComment('MouseflowExcludeEnd'))
+        span.insertBefore(document.createComment(COMMENT_START), firstChild)
+        span.appendChild(document.createComment(COMMENT_END))
       }}>
         {this.props.children}
       </span>

--- a/MouseflowExclude/index.jsx
+++ b/MouseflowExclude/index.jsx
@@ -8,17 +8,19 @@ const MouseflowExclude = React.createClass({
   render () {
     return (
       <span ref={(span) => {
-        if (span == null) {
+        const firstChild = span && span.childNodes && span.childNodes[0]
+
+        if (firstChild == null) {
           return
         }
 
-        if (span.childNodes[0].nodeType === NODE_COMMENT && span.childNodes[0].textContent === 'MouseflowExcludeStart') {
+        if (firstChild.nodeType === NODE_COMMENT && firstChild.textContent === 'MouseflowExcludeStart') {
           return
         }
 
         span.insertBefore(
           document.createComment('MouseflowExcludeStart'),
-          span.childNodes[0]
+          firstChild
         )
 
         span.appendChild(document.createComment('MouseflowExcludeEnd'))


### PR DESCRIPTION
We're using MouseflowExclude in our project and started noticing these errors:

    TypeError: undefined is not an object (evaluating 'span.childNodes[0].nodeType')

I believe this is because some unit tests will mount our components and not provide the props required to render the stuff that is supposed to be between the `<MouseflowExclude>` tags. Therefore there are no childNodes to the `span`, and it throws an error.

I think the component should handle this case, for testing-convenience, but also to avoid unnecessary runtime errors that may happen.