### PR TITLE
Fix Collapsible allowing content to overflow

### DIFF
--- a/Collapsible/index.jsx
+++ b/Collapsible/index.jsx
@@ -32,14 +32,9 @@ export default class Collapsible extends Component {
       }}>
         {({height, opacity}) => <div
           style={{
-            // once it is fully expanded, we set the heigh to auto
-            // and let the browser take care of the size
             height: getHeight(collapsed, height, this.state.height),
             opacity,
-            // Overflow rule to enable content to overflow outside the collapsible
-            // once the animation is close to be complete (the last few pixels take a while
-            // to be expanded). '10' is a magic number 🎩
-            overflow: this.state.height - height > 10 ? 'hidden' : 'visible'
+            overflow: shouldOverflow(collapsed, height, this.state.height)
           }}>
           {children}
         </div>}
@@ -48,6 +43,20 @@ export default class Collapsible extends Component {
   }
 }
 
+/**
+ * Overflow rule to enable content to overflow outside the collapsible
+ * once the animation is close to be complete (the last few pixels take a while
+ * to be expanded). '10' is a magic number 🎩
+ */
+const shouldOverflow = (collapsed, animatedHeight, actualHeight) => {
+  const notYetAlmostExpanded = actualHeight - animatedHeight > 10
+  return (collapsed || notYetAlmostExpanded) ? 'hidden' : 'visible'
+}
+
+/**
+ * Once it is fully expanded, we set the heigh to auto
+ * and let the browser take care of the size
+ */
 const getHeight = (collapsed, animatedHeight, actualHeight) => {
   if (collapsed) { return animatedHeight }
   return animatedHeight === actualHeight ? 'auto' : animatedHeight


### PR DESCRIPTION
The current implementation leaves all Collapsibles as `overflow: visible` on mount. However it only manifest itself as an issue in IE11.

- Move around the documentation explaining the reasoning
- Add an extra rule that keeps the overflow hidden while collapsed