### PR TITLE
Partially collapsed Radio selector

### DIFF
--- a/Collapsible/index.jsx
+++ b/Collapsible/index.jsx
@@ -27,13 +27,13 @@ export default class Collapsible extends Component {
   }
 
   render () {
-    const {children, collapsed, onEndFPSCollection} = this.props
+    const {children, collapsed, defaultCollapsed, onEndFPSCollection} = this.props
 
     return <div ref={(div) => { this.content = div }}>
       {
         this.props.lowFPS
           ? this.renderRegular(children, collapsed)
-          : this.renderAnimation(children, collapsed, onEndFPSCollection)
+          : this.renderAnimation(children, defaultCollapsed, collapsed, onEndFPSCollection)
       }
     </div>
   }
@@ -49,9 +49,13 @@ export default class Collapsible extends Component {
     )
   }
 
-  renderAnimation (children, collapsed, onEndFPSCollection) {
+  renderAnimation (children, defaultCollapsed, collapsed, onEndFPSCollection) {
     return (
       <Motion
+        defaultStyles={defaultCollapsed ? {
+          height: collapsed ? 0 : this.state.height,
+          opacity: collapsed ? 0 : 1
+        } : undefined}
         style={{
           height: spring(collapsed ? 0 : this.state.height),
           opacity: spring(collapsed ? 0 : 1)

--- a/Collapsible/index.jsx
+++ b/Collapsible/index.jsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react'
+import React, {Component, PropTypes} from 'react'
 import {Motion, spring} from 'react-motion'
 
 export default class Collapsible extends Component {
@@ -27,13 +27,13 @@ export default class Collapsible extends Component {
   }
 
   render () {
-    const {children, collapsed, defaultCollapsed, onEndFPSCollection} = this.props
+    const {children, collapsed, defaultCollapsed, onEndFPSCollection, minimumHeight} = this.props
 
     return <div ref={(div) => { this.content = div }}>
       {
         this.props.lowFPS
           ? this.renderRegular(children, collapsed)
-          : this.renderAnimation(children, defaultCollapsed, collapsed, onEndFPSCollection)
+          : this.renderAnimation(children, defaultCollapsed, collapsed, onEndFPSCollection, minimumHeight)
       }
     </div>
   }
@@ -49,21 +49,25 @@ export default class Collapsible extends Component {
     )
   }
 
-  renderAnimation (children, defaultCollapsed, collapsed, onEndFPSCollection) {
+  renderAnimation (children, defaultCollapsed, collapsed, onEndFPSCollection, minimumHeight) {
     return (
       <Motion
         defaultStyles={defaultCollapsed ? {
-          height: collapsed ? 0 : this.state.height,
+          height: collapsed ? minimumHeight : this.state.height,
           opacity: collapsed ? 0 : 1
         } : undefined}
         style={{
-          height: spring(collapsed ? 0 : this.state.height),
+          height: spring(collapsed ? minimumHeight : this.state.height),
           opacity: spring(collapsed ? 0 : 1)
         }}
         onRest={onEndFPSCollection}>
         {({height, opacity}) => <div
           style={{
-            height: getHeight(collapsed, height, this.state.height),
+            height: getHeight(
+              collapsed,
+              height + calculateHeight(this.content) - this.state.height,
+              calculateHeight(this.content)
+            ),
             opacity,
             overflow: shouldOverflow(collapsed, height, this.state.height)
           }}>
@@ -72,6 +76,14 @@ export default class Collapsible extends Component {
       </Motion>
     )
   }
+}
+
+Collapsible.propTypes = {
+  minimumHeight: PropTypes.number
+}
+
+Collapsible.defaultProps = {
+  minimumHeight: 0
 }
 
 /**

--- a/Radio/ExpandLabel/index.js
+++ b/Radio/ExpandLabel/index.js
@@ -1,0 +1,28 @@
+import React, {PropTypes} from 'react'
+import deepMerge from 'deepmerge'
+import compose from 'ramda/src/compose'
+import withHoverStyles from '../../lib/toMoveToHoCs/withHoverStyles'
+
+import * as Chevron from '../../icons/Chevron'
+import defaultStyles, {chevron} from './styles'
+
+function ExpandLabel ({label, styles, ...props}) {
+  const finalStyles = deepMerge(defaultStyles.base, styles)
+
+  return <footer style={finalStyles} {...props}>
+    {label} <Chevron.Down color='black' style={chevron} />
+  </footer>
+}
+
+ExpandLabel.propTypes = {
+  label: PropTypes.string.isRequired,
+  styles: PropTypes.object
+}
+
+ExpandLabel.defaultProps = {
+  styles: {}
+}
+
+export default compose(
+  withHoverStyles(defaultStyles.hover)
+)(ExpandLabel)

--- a/Radio/ExpandLabel/index.js
+++ b/Radio/ExpandLabel/index.js
@@ -6,10 +6,10 @@ import withHoverStyles from '../../lib/toMoveToHoCs/withHoverStyles'
 import * as Chevron from '../../icons/Chevron'
 import defaultStyles, {chevron} from './styles'
 
-function ExpandLabel ({label, styles, ...props}) {
+function ExpandLabel ({label, style, styles, ...props}) {
   const finalStyles = deepMerge(defaultStyles.base, styles)
 
-  return <footer style={finalStyles} {...props}>
+  return <footer style={{...finalStyles, ...style}} {...props}>
     {label} <Chevron.Down color='black' style={chevron} />
   </footer>
 }

--- a/Radio/ExpandLabel/index.js
+++ b/Radio/ExpandLabel/index.js
@@ -2,6 +2,7 @@ import React, {PropTypes} from 'react'
 import deepMerge from 'deepmerge'
 import compose from 'ramda/src/compose'
 import withHoverStyles from '../../lib/toMoveToHoCs/withHoverStyles'
+import withTouchStyles from '../../lib/toMoveToHoCs/withTouchStyles'
 
 import * as Chevron from '../../icons/Chevron'
 import defaultStyles, {chevron} from './styles'
@@ -24,5 +25,6 @@ ExpandLabel.defaultProps = {
 }
 
 export default compose(
-  withHoverStyles(defaultStyles.hover)
+  withHoverStyles(defaultStyles.active),
+  withTouchStyles(defaultStyles.active)
 )(ExpandLabel)

--- a/Radio/ExpandLabel/styles.js
+++ b/Radio/ExpandLabel/styles.js
@@ -7,17 +7,21 @@ import grid from '../../settings/grid'
 export default {
   base: {
     backgroundColor: LIGHT_GREY.base,
+    bottom: 0,
     cursor: 'pointer',
     display: 'block',
     height: grid(4),
     lineHeight: grid(4),
     paddingTop: grid(1.8),
     paddingBottom: grid(4),
+    position: 'absolute',
     textAlign: 'center',
     fontSize: grid(MAIN_BODY_BIG.desktop),
     fontFamily: fontFamilies.BASE,
     fontWeight: fontWeights.SEMI_BOLD,
-    transition: 'background-color .2s linear'
+    transition: 'background-color .2s linear',
+    width: '100%',
+    zIndex: 1
   },
 
   hover: {

--- a/Radio/ExpandLabel/styles.js
+++ b/Radio/ExpandLabel/styles.js
@@ -1,0 +1,30 @@
+import {LIGHT_GREY} from '../../settings/palette'
+import {MAIN_BODY_BIG} from '../../settings/fontSizes'
+import * as fontFamilies from '../../settings/fontFamilies'
+import * as fontWeights from '../../settings/fontWeights'
+import grid from '../../settings/grid'
+
+export default {
+  base: {
+    backgroundColor: LIGHT_GREY.base,
+    cursor: 'pointer',
+    display: 'block',
+    height: grid(4),
+    lineHeight: grid(4),
+    paddingTop: grid(1.8),
+    paddingBottom: grid(4),
+    textAlign: 'center',
+    fontSize: grid(MAIN_BODY_BIG.desktop),
+    fontFamily: fontFamilies.BASE,
+    fontWeight: fontWeights.SEMI_BOLD,
+    transition: 'background-color .2s linear'
+  },
+
+  hover: {
+    backgroundColor: LIGHT_GREY.hover
+  }
+}
+
+export const chevron = {
+  transform: `translateY(${grid(1)})`
+}

--- a/Radio/ExpandLabel/styles.js
+++ b/Radio/ExpandLabel/styles.js
@@ -24,7 +24,7 @@ export default {
     zIndex: 1
   },
 
-  hover: {
+  active: {
     backgroundColor: LIGHT_GREY.hover
   }
 }

--- a/Radio/example.jsx
+++ b/Radio/example.jsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import compose from 'ramda/src/compose'
+import {withState, withHandlers} from 'recompose'
 import Radio from '../Radio'
 import * as Checklist from '../Checklist'
 import * as Paragraph from '../Paragraph'
@@ -72,6 +74,16 @@ const optionsWithContent = [
   }
 ]
 
+const StateFullyCollapsed = compose(
+  withState('fullyExpanded', 'onExpand', false),
+  withHandlers({
+    onExpand: props => () => {
+      console.log('this is being called')
+      props.onExpand(!props.fullyExpanded)
+    }
+  })
+)(Radio)
+
 export default {
   title: 'Radio',
 
@@ -80,84 +92,84 @@ export default {
     type: LIVE_WIDE,
 
     examples: {
-      Regular: <Radio
-        onChange={(key) => console.log(key)}
-        options={optionsWithContent}
-        defaultValue='lorem'
-      />,
+      // Regular: <Radio
+      //   onChange={(key) => console.log(key)}
+      //   options={optionsWithContent}
+      //   defaultValue='lorem'
+      // />,
+      //
+      // 'Without content': <Radio
+      //   onChange={(key) => console.log(key)}
+      //   options={options}
+      // />,
 
-      'Without content': <Radio
-        onChange={(key) => console.log(key)}
-        options={options}
-      />,
-
-      'Partially collapsed': <Radio
+      'Partially collapsed': <StateFullyCollapsed
         options={optionsWithContent}
-        expandedOptions={1}
         expandLabel='Show me all the options'
+        collapsedOptions={2}
       />,
-
-      Controlled: <Radio
-        focus='sit'
-        name='radio'
-        onChange={(key) => console.log(key)}
-        options={options}
-        value='ipsum'
-      />,
-
-      Borderless: <Radio
-        borderless
-        onChange={(key) => console.log(key)}
-        options={options}
-        defaultValue='lorem'
-      />,
-
-      Disabled: <Radio
-        disabled
-        onChange={(key) => console.log(key)}
-        options={options}
-        defaultValue='lorem'
-      />,
-
-      'One field disabled': <Radio
-        onChange={(key) => console.log(key)}
-        options={[
-          ...optionsWithContent.slice(0, 2),
-          {...optionsWithContent[2], disabled: true}
-        ]}
-        defaultValue='lorem'
-      />,
-
-      'Borderless and disabled': <Radio
-        borderless
-        disabled
-        options={options}
-        defaultValue='lorem'
-      />,
-
-      'With a single option': <Radio
-        options={[{
-          key: 'lorem',
-          label: 'Lorem',
-          description: 'Lorem Ipsum is simply dummy.',
-          aside: card,
-          content: <Paragraph.Secondary condensed>
-            Offal man braid XOXO DIY, pok pok tbh poke post-ironic neutra try-hard small batch.
-          </Paragraph.Secondary>,
-          leftPad: true
-        }]}
-      />,
-
-      'Dynamic styling': <Radio
-        customize={{
-          backgroundColor: '#660080',
-          borderRadius: '10px',
-          bulletColor: '#00ce3e',
-          textPrimaryColor: 'green',
-          textSecondaryColor: 'red'
-        }}
-        options={options}
-      />
+      //
+      // Controlled: <Radio
+      //   focus='sit'
+      //   name='radio'
+      //   onChange={(key) => console.log(key)}
+      //   options={options}
+      //   value='ipsum'
+      // />,
+      //
+      // Borderless: <Radio
+      //   borderless
+      //   onChange={(key) => console.log(key)}
+      //   options={options}
+      //   defaultValue='lorem'
+      // />,
+      //
+      // Disabled: <Radio
+      //   disabled
+      //   onChange={(key) => console.log(key)}
+      //   options={options}
+      //   defaultValue='lorem'
+      // />,
+      //
+      // 'One field disabled': <Radio
+      //   onChange={(key) => console.log(key)}
+      //   options={[
+      //     ...optionsWithContent.slice(0, 2),
+      //     {...optionsWithContent[2], disabled: true}
+      //   ]}
+      //   defaultValue='lorem'
+      // />,
+      //
+      // 'Borderless and disabled': <Radio
+      //   borderless
+      //   disabled
+      //   options={options}
+      //   defaultValue='lorem'
+      // />,
+      //
+      // 'With a single option': <Radio
+      //   options={[{
+      //     key: 'lorem',
+      //     label: 'Lorem',
+      //     description: 'Lorem Ipsum is simply dummy.',
+      //     aside: card,
+      //     content: <Paragraph.Secondary condensed>
+      //       Offal man braid XOXO DIY, pok pok tbh poke post-ironic neutra try-hard small batch.
+      //     </Paragraph.Secondary>,
+      //     leftPad: true
+      //   }]}
+      // />,
+      //
+      // 'Dynamic styling': <Radio
+      //   customize={{
+      //     backgroundColor: '#660080',
+      //     borderRadius: '10px',
+      //     bulletColor: '#00ce3e',
+      //     textPrimaryColor: 'green',
+      //     textSecondaryColor: 'red'
+      //   }}
+      //   options={options}
+      // />
     }
   }
 }

--- a/Radio/example.jsx
+++ b/Radio/example.jsx
@@ -108,6 +108,27 @@ export default {
         expandLabel='Show me all the options'
         collapsedOptions={2}
       />,
+
+    'Partially collapsed & preselected': <StateFullyCollapsed
+        options={optionsWithContent}
+        expandLabel='Show me all the options'
+        defaultValue='ipsum'
+        collapsedOptions={2}
+      />,
+
+    'Partially collapsed & first selected': <StateFullyCollapsed
+        options={optionsWithContent}
+        expandLabel='Show me all the options'
+        defaultValue='lorem'
+        collapsedOptions={2}
+      />,
+
+    'Partially collapsed & wrong one selected': <StateFullyCollapsed
+        options={optionsWithContent}
+        expandLabel='Show me all the options'
+        defaultValue='asdfasdf'
+        collapsedOptions={2}
+      />,
       //
       // Controlled: <Radio
       //   focus='sit'

--- a/Radio/example.jsx
+++ b/Radio/example.jsx
@@ -1,6 +1,4 @@
 import React from 'react'
-import compose from 'ramda/src/compose'
-import {withState, withHandlers} from 'recompose'
 import Radio from '../Radio'
 import * as Checklist from '../Checklist'
 import * as Paragraph from '../Paragraph'
@@ -74,16 +72,6 @@ const optionsWithContent = [
   }
 ]
 
-const StateFullyCollapsed = compose(
-  withState('fullyExpanded', 'onExpand', false),
-  withHandlers({
-    onExpand: props => () => {
-      console.log('this is being called')
-      props.onExpand(!props.fullyExpanded)
-    }
-  })
-)(Radio)
-
 export default {
   title: 'Radio',
 
@@ -92,105 +80,91 @@ export default {
     type: LIVE_WIDE,
 
     examples: {
-      // Regular: <Radio
-      //   onChange={(key) => console.log(key)}
-      //   options={optionsWithContent}
-      //   defaultValue='lorem'
-      // />,
-      //
-      // 'Without content': <Radio
-      //   onChange={(key) => console.log(key)}
-      //   options={options}
-      // />,
-
-      'Partially collapsed': <StateFullyCollapsed
+      Regular: <Radio
+        onChange={(key) => console.log(key)}
         options={optionsWithContent}
-        expandLabel='Show me all the options'
-        collapsedOptions={2}
-      />,
-
-      'Partially collapsed & preselected': <StateFullyCollapsed
-        options={optionsWithContent}
-        expandLabel='Show me all the options'
-        defaultValue='ipsum'
-        collapsedOptions={2}
-      />,
-
-      'Partially collapsed & first selected': <StateFullyCollapsed
-        options={optionsWithContent}
-        expandLabel='Show me all the options'
         defaultValue='lorem'
+      />,
+
+      'Without content': <Radio
+        onChange={(key) => console.log(key)}
+        options={options}
+      />,
+
+      'Partially collapsed': <Radio
+        options={optionsWithContent}
+        expandLabel='Show me all the options'
         collapsedOptions={2}
       />,
 
-      'Partially collapsed & wrong one selected': <StateFullyCollapsed
+      Controlled: <Radio
+        focus='sit'
+        name='radio'
+        onChange={(key) => console.log(key)}
+        options={options}
+        value='ipsum'
+      />,
+
+      'Partially collapsed & controlled': <Radio
         options={optionsWithContent}
         expandLabel='Show me all the options'
-        defaultValue='asdfasdf'
         collapsedOptions={2}
+        fullyExpanded={false}
       />,
-      //
-      // Controlled: <Radio
-      //   focus='sit'
-      //   name='radio'
-      //   onChange={(key) => console.log(key)}
-      //   options={options}
-      //   value='ipsum'
-      // />,
-      //
-      // Borderless: <Radio
-      //   borderless
-      //   onChange={(key) => console.log(key)}
-      //   options={options}
-      //   defaultValue='lorem'
-      // />,
-      //
-      // Disabled: <Radio
-      //   disabled
-      //   onChange={(key) => console.log(key)}
-      //   options={options}
-      //   defaultValue='lorem'
-      // />,
-      //
-      // 'One field disabled': <Radio
-      //   onChange={(key) => console.log(key)}
-      //   options={[
-      //     ...optionsWithContent.slice(0, 2),
-      //     {...optionsWithContent[2], disabled: true}
-      //   ]}
-      //   defaultValue='lorem'
-      // />,
-      //
-      // 'Borderless and disabled': <Radio
-      //   borderless
-      //   disabled
-      //   options={options}
-      //   defaultValue='lorem'
-      // />,
-      //
-      // 'With a single option': <Radio
-      //   options={[{
-      //     key: 'lorem',
-      //     label: 'Lorem',
-      //     description: 'Lorem Ipsum is simply dummy.',
-      //     aside: card,
-      //     content: <Paragraph.Secondary condensed>
-      //       Offal man braid XOXO DIY, pok pok tbh poke post-ironic neutra try-hard small batch.
-      //     </Paragraph.Secondary>,
-      //     leftPad: true
-      //   }]}
-      // />,
-      //
-      // 'Dynamic styling': <Radio
-      //   customize={{
-      //     backgroundColor: '#660080',
-      //     borderRadius: '10px',
-      //     bulletColor: '#00ce3e',
-      //     textPrimaryColor: 'green',
-      //     textSecondaryColor: 'red'
-      //   }}
-      //   options={options}
-      // />
+
+      Borderless: <Radio
+        borderless
+        onChange={(key) => console.log(key)}
+        options={options}
+        defaultValue='lorem'
+      />,
+
+      Disabled: <Radio
+        disabled
+        onChange={(key) => console.log(key)}
+        options={options}
+        defaultValue='lorem'
+      />,
+
+      'One field disabled': <Radio
+        onChange={(key) => console.log(key)}
+        options={[
+          ...optionsWithContent.slice(0, 2),
+          {...optionsWithContent[2], disabled: true}
+        ]}
+        defaultValue='lorem'
+      />,
+
+      'Borderless and disabled': <Radio
+        borderless
+        disabled
+        options={options}
+        defaultValue='lorem'
+      />,
+
+      'With a single option': <Radio
+        options={[{
+          key: 'lorem',
+          label: 'Lorem',
+          description: 'Lorem Ipsum is simply dummy.',
+          aside: card,
+          content: <Paragraph.Secondary condensed>
+            Offal man braid XOXO DIY, pok pok tbh poke post-ironic neutra try-hard small batch.
+          </Paragraph.Secondary>,
+          leftPad: true
+        }]}
+      />,
+
+      'Dynamic styling': <Radio
+        customize={{
+          backgroundColor: '#660080',
+          borderRadius: '10px',
+          bulletColor: '#00ce3e',
+          textPrimaryColor: 'green',
+          textSecondaryColor: 'red'
+        }}
+        options={options}
+      />
     }
   }
 }

--- a/Radio/example.jsx
+++ b/Radio/example.jsx
@@ -109,21 +109,21 @@ export default {
         collapsedOptions={2}
       />,
 
-    'Partially collapsed & preselected': <StateFullyCollapsed
+      'Partially collapsed & preselected': <StateFullyCollapsed
         options={optionsWithContent}
         expandLabel='Show me all the options'
         defaultValue='ipsum'
         collapsedOptions={2}
       />,
 
-    'Partially collapsed & first selected': <StateFullyCollapsed
+      'Partially collapsed & first selected': <StateFullyCollapsed
         options={optionsWithContent}
         expandLabel='Show me all the options'
         defaultValue='lorem'
         collapsedOptions={2}
       />,
 
-    'Partially collapsed & wrong one selected': <StateFullyCollapsed
+      'Partially collapsed & wrong one selected': <StateFullyCollapsed
         options={optionsWithContent}
         expandLabel='Show me all the options'
         defaultValue='asdfasdf'

--- a/Radio/example.jsx
+++ b/Radio/example.jsx
@@ -94,7 +94,7 @@ export default {
       'Partially collapsed': <Radio
         options={optionsWithContent}
         expandLabel='Show me all the options'
-        collapsedOptions={2}
+        visibleOptions={1}
       />,
 
       Controlled: <Radio
@@ -108,7 +108,7 @@ export default {
       'Partially collapsed & controlled': <Radio
         options={optionsWithContent}
         expandLabel='Show me all the options'
-        collapsedOptions={2}
+        visibleOptions={1}
         fullyExpanded={false}
       />,
 

--- a/Radio/example.jsx
+++ b/Radio/example.jsx
@@ -91,6 +91,12 @@ export default {
         options={options}
       />,
 
+      'Partially collapsed': <Radio
+        options={optionsWithContent}
+        expandedOptions={1}
+        expandLabel='Show me all the options'
+      />,
+
       Controlled: <Radio
         focus='sit'
         name='radio'

--- a/Radio/index.jsx
+++ b/Radio/index.jsx
@@ -59,7 +59,7 @@ class Radio extends Component {
       focus,
       options,
       disabled: allDisabled,
-      collapsedOptions,
+      visibleOptions,
       expandLabel,
       fullyExpanded,
       name,
@@ -82,11 +82,11 @@ class Radio extends Component {
     const descriptionStyle = customize ? { color: customize.textSecondaryColor } : undefined
 
     const optionLists = {
-      visible: collapsedOptions
-        ? options.slice(0, -collapsedOptions)
+      visible: visibleOptions
+        ? options.slice(0, visibleOptions)
         : options,
-      collapsed: collapsedOptions
-        ? options.slice(-collapsedOptions)
+      collapsed: visibleOptions
+        ? options.slice(visibleOptions)
         : []
     }
 
@@ -217,7 +217,7 @@ class Radio extends Component {
           ]
         })}
 
-        {collapsedOptions && <Collapsible
+        {visibleOptions && <Collapsible
           onStartFPSCollection={onStartFPSCollection}
           onEndFPSCollection={onEndFPSCollection}
           lowFPS={lowFPS}
@@ -378,7 +378,7 @@ Radio.propTypes = {
     textSecondaryColor: PropTypes.string.isRequired
   }),
   disabled: PropTypes.bool,
-  collapsedOptions: PropTypes.number,
+  visibleOptions: PropTypes.number,
   expandLabel: PropTypes.string,
   fullyExpanded: PropTypes.bool,
   onExpand: PropTypes.func,

--- a/Radio/index.jsx
+++ b/Radio/index.jsx
@@ -1,10 +1,5 @@
-import React, { PropTypes } from 'react'
+import React, { Component, PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import Collapsible from '../Collapsible'
-import defaultStyles from './styles.scss'
-import getActiveElement from '../lib/getActiveElement'
-import RadioMark from '../RadioMark'
-
 import compose from 'ramda/src/compose'
 import {
   notifyOnLowFPS,
@@ -12,6 +7,12 @@ import {
   uncontrolled,
   uniqueName
 } from '@klarna/higher-order-components'
+
+import Collapsible from '../Collapsible'
+import defaultStyles from './styles.scss'
+import getActiveElement from '../lib/getActiveElement'
+import RadioMark from '../RadioMark'
+import ExpandLabel from './ExpandLabel'
 
 const baseClass = 'radio'
 
@@ -31,34 +32,7 @@ const classes = {
   optionContent: `${baseClass}__option__content`
 }
 
-const Radio = React.createClass({
-  displayName: 'Radio',
-
-  propTypes: {
-    borderless: PropTypes.bool,
-    className: PropTypes.string,
-    customize: PropTypes.shape({
-      backgroundColor: PropTypes.string.isRequired,
-      borderRadius: PropTypes.string.isRequired,
-      bulletColor: PropTypes.string.isRequired,
-      textPrimaryColor: PropTypes.string.isRequired,
-      textSecondaryColor: PropTypes.string.isRequired
-    }),
-    disabled: PropTypes.bool,
-    focus: PropTypes.string,
-    id: PropTypes.string,
-    name: PropTypes.string,
-    onBlur: PropTypes.func,
-    onChange: PropTypes.func,
-    onFocus: PropTypes.func,
-    onEndFPSCollection: PropTypes.func,
-    onStartFPSCollection: PropTypes.func,
-    lowFPS: PropTypes.bool,
-    options: PropTypes.array.isRequired,
-    styles: PropTypes.object,
-    value: PropTypes.any
-  },
-
+class Radio extends Component {
   componentDidMount () {
     if (
       this.props.focus &&
@@ -66,7 +40,7 @@ const Radio = React.createClass({
     ) {
       this.refs[this.props.focus].focus()
     }
-  },
+  }
 
   componentDidUpdate () {
     if (
@@ -75,7 +49,7 @@ const Radio = React.createClass({
     ) {
       this.refs[this.props.focus].focus()
     }
-  },
+  }
 
   render () {
     const {
@@ -85,6 +59,8 @@ const Radio = React.createClass({
       focus,
       options,
       disabled: allDisabled,
+      expandedOptions,
+      expandLabel,
       name,
       onBlur,
       onChange,
@@ -225,10 +201,38 @@ const Radio = React.createClass({
             </div>
           ]
         })}
+        {expandLabel && <ExpandLabel label={expandLabel} />}
       </div>
     )
   }
-})
+}
+
+Radio.propTypes = {
+  borderless: PropTypes.bool,
+  className: PropTypes.string,
+  customize: PropTypes.shape({
+    backgroundColor: PropTypes.string.isRequired,
+    borderRadius: PropTypes.string.isRequired,
+    bulletColor: PropTypes.string.isRequired,
+    textPrimaryColor: PropTypes.string.isRequired,
+    textSecondaryColor: PropTypes.string.isRequired
+  }),
+  disabled: PropTypes.bool,
+  expandedOptions: PropTypes.number,
+  expandLabel: PropTypes.string,
+  focus: PropTypes.string,
+  id: PropTypes.string,
+  name: PropTypes.string,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  onEndFPSCollection: PropTypes.func,
+  onStartFPSCollection: PropTypes.func,
+  lowFPS: PropTypes.bool,
+  options: PropTypes.array.isRequired,
+  styles: PropTypes.object,
+  value: PropTypes.any
+}
 
 export default compose(
   notifyOnLowFPS({threshold: 10}),

--- a/Radio/index.jsx
+++ b/Radio/index.jsx
@@ -90,6 +90,10 @@ class Radio extends Component {
         : []
     }
 
+    const isExpanded = fullyExpanded || (
+      value && optionLists.collapsed.find(({key}) => key === value) != null
+    )
+
     return (
       <div
         className={classNames(baseClass, {
@@ -217,7 +221,8 @@ class Radio extends Component {
           onStartFPSCollection={onStartFPSCollection}
           onEndFPSCollection={onEndFPSCollection}
           lowFPS={lowFPS}
-          collapsed={!fullyExpanded}>
+          minimumHeight={49}
+          collapsed={!isExpanded}>
           <div>
             {optionLists.collapsed.map((option) => {
               const {
@@ -334,12 +339,28 @@ class Radio extends Component {
           </div>
         </Collapsible>}
 
-        {expandLabel && <Motion style={{opacity: spring(fullyExpanded ? 0 : 1)}}>
-          {({opacity}) => <ExpandLabel
-            onClick={onExpand}
-            label={expandLabel}
-            style={{opacity}}
-          />}
+        {expandLabel && <Motion
+          style={{
+            opacity: spring(isExpanded ? 0 : 1),
+            height: spring(isExpanded ? 0 : 49, {stiffness: 40, damping: 15})
+          }}>
+          {({opacity, height}) => opacity > 0 && <div>
+            <div
+              style={{
+                position: 'absolute',
+                bottom: 0,
+                width: '100%',
+                backgroundColor: 'white',
+                boxShadow: 'white 0 0 5px',
+                height
+              }}
+            />
+            <ExpandLabel
+              onClick={onExpand}
+              label={expandLabel}
+              style={{opacity}}
+            />
+          </div>}
         </Motion>}
       </div>
     )

--- a/Radio/index.jsx
+++ b/Radio/index.jsx
@@ -403,6 +403,13 @@ Radio.defaultProps = {
 export default compose(
   notifyOnLowFPS({threshold: 10}),
   uncontrolled({
+    prop: 'fullyExpanded',
+    defaultProp: 'autoFullyExpanded',
+    handlers: {
+      onExpand: () => () => true
+    }
+  }),
+  uncontrolled({
     prop: 'focus',
     defaultProp: 'autoFocus',
     handlers: {

--- a/lib/toMoveToHoCs/withHoverStyles.js
+++ b/lib/toMoveToHoCs/withHoverStyles.js
@@ -1,0 +1,34 @@
+import React, {Component} from 'react'
+import deepMerge from 'deepmerge'
+
+export default hoverStyles => Target => {
+  class WithHoverStyles extends Component {
+    constructor () {
+      super()
+
+      this.state = {
+        hovered: false
+      }
+    }
+
+    render () {
+      const {styles, onMouseEnter, onMouseLeave, ...props} = this.props
+      const {hovered} = this.state
+
+      return <Target
+        onMouseEnter={(...args) => {
+          this.setState({hovered: true})
+          onMouseEnter && onMouseEnter(...args)
+        }}
+        onMouseLeave={(...args) => {
+          this.setState({hovered: false})
+          onMouseLeave && onMouseLeave(...args)
+        }}
+        styles={hovered ? deepMerge(hoverStyles, styles || {}) : styles}
+        {...props}
+      />
+    }
+  }
+
+  return WithHoverStyles
+}

--- a/lib/toMoveToHoCs/withHoverStyles.js
+++ b/lib/toMoveToHoCs/withHoverStyles.js
@@ -24,7 +24,7 @@ export default hoverStyles => Target => {
           this.setState({hovered: false})
           onMouseLeave && onMouseLeave(...args)
         }}
-        styles={hovered ? deepMerge(hoverStyles, styles || {}) : styles}
+        styles={hovered ? deepMerge(hoverStyles, styles || {}) : styles}
         {...props}
       />
     }

--- a/lib/toMoveToHoCs/withTouchStyles.js
+++ b/lib/toMoveToHoCs/withTouchStyles.js
@@ -24,7 +24,7 @@ export default hoverStyles => Target => {
           this.setState({touched: false})
           onTouchEnd && onTouchEnd(...args)
         }}
-        styles={touched ? deepMerge(hoverStyles, styles || {}) : styles}
+        styles={touched ? deepMerge(hoverStyles, styles || {}) : styles}
         {...props}
       />
     }

--- a/lib/toMoveToHoCs/withTouchStyles.js
+++ b/lib/toMoveToHoCs/withTouchStyles.js
@@ -1,0 +1,34 @@
+import React, {Component} from 'react'
+import deepMerge from 'deepmerge'
+
+export default hoverStyles => Target => {
+  class WithHoverStyles extends Component {
+    constructor () {
+      super()
+
+      this.state = {
+        touched: false
+      }
+    }
+
+    render () {
+      const {styles, onTouchStart, onTouchEnd, ...props} = this.props
+      const {touched} = this.state
+
+      return <Target
+        onTouchStart={(...args) => {
+          this.setState({touched: true})
+          onTouchStart && onTouchStart(...args)
+        }}
+        onTouchEnd={(...args) => {
+          this.setState({touched: false})
+          onTouchEnd && onTouchEnd(...args)
+        }}
+        styles={touched ? deepMerge(hoverStyles, styles || {}) : styles}
+        {...props}
+      />
+    }
+  }
+
+  return WithHoverStyles
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@klarna/higher-order-components": "0.5.6",
     "classnames": "2.2.5",
+    "deepmerge": "^1.3.2",
     "parse-color": "1.0.0",
     "react-context-props": "^0.1.4"
   },
@@ -82,9 +83,9 @@
     "zen-router": "^1.0.0"
   },
   "peerDependencies": {
+    "ramda": "^0.21.0",
     "react": "^0.14.0 || ^15.0.0",
-    "react-motion": "^0.4.2",
-    "ramda": "^0.21.0"
+    "react-motion": "^0.4.2"
   },
   "standard": {
     "globals": [

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react-maskedinput": "^3.3.1",
     "react-motion": "^0.4.2",
     "react-syntax-highlighter": "^2.2.0",
+    "recompose": "^0.22.0",
     "resolve-url-loader": "^1.2.0",
     "sass-lint": "^1.9.1",
     "sass-loader": "^3.2.0",

--- a/settings/fontFamilies.js
+++ b/settings/fontFamilies.js
@@ -1,3 +1,3 @@
-export const BASE = '\'Open Sans\', \'Helvetica Neue\', \'Helvetica\', \'Arial\', sans-serif'
+export const BASE = `'Open Sans', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif'`
 
-export const CODE = '\'Fira Code\', \'Consolas\', \'Menlo\', \'Andale Mono\', monospace'
+export const CODE = `'Fira Code', 'Consolas', 'Menlo', 'Andale Mono', monospace`

--- a/settings/fontFamilies.js
+++ b/settings/fontFamilies.js
@@ -1,0 +1,3 @@
+export const BASE = '\'Open Sans\', \'Helvetica Neue\', \'Helvetica\', \'Arial\', sans-serif'
+
+export const CODE = '\'Fira Code\', \'Consolas\', \'Menlo\', \'Andale Mono\', monospace'

--- a/settings/fontSizes.js
+++ b/settings/fontSizes.js
@@ -1,0 +1,4 @@
+export const MAIN_BODY_BIG = {
+  desktop: 2.8,
+  mobile: 2.8
+}

--- a/settings/fontWeights.js
+++ b/settings/fontWeights.js
@@ -1,0 +1,4 @@
+export const LIGHT = 300
+export const REGULAR = 400
+export const SEMI_BOLD = 600
+export const BOLD = 700

--- a/settings/grid.js
+++ b/settings/grid.js
@@ -1,0 +1,3 @@
+const GRID_SIZE_IN_PIXELS = 5
+
+export default gridMultiple => `${gridMultiple * GRID_SIZE_IN_PIXELS}px`

--- a/settings/palette.js
+++ b/settings/palette.js
@@ -1,0 +1,4 @@
+export const LIGHT_GREY = {
+  base: '#F5F5F7',
+  hover: '#EDEDEF'
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1707,6 +1707,10 @@ deep-is@~0.1.2, deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+deepmerge@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.3.2.tgz#1663691629d4dbfe364fa12a2a4f0aa86aa3a050"
+
 defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
@@ -3602,11 +3606,7 @@ lowlight@^1.2.0:
   dependencies:
     highlight.js "~9.9.0"
 
-lru-cache@2:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
-
-lru-cache@2.2.x:
+lru-cache@2, lru-cache@2.2.x:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,6 +1224,10 @@ change-case@2.3.x:
     upper-case "^1.1.1"
     upper-case-first "^1.1.0"
 
+change-emitter@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.2.tgz#6b88ca4d5d864e516f913421b11899a860aee8db"
+
 chokidar@^1.0.0, chokidar@^1.4.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.6.1.tgz#2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2"
@@ -2751,6 +2755,10 @@ highlight.js@~9.9.0:
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
+
+hoist-non-react-statics@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -4812,6 +4820,15 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+recompose@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.22.0.tgz#f099d18385882ca41d9eec891718dadddc3204ef"
+  dependencies:
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^1.0.0"
+    symbol-observable "^1.0.4"
+
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
@@ -5553,6 +5570,10 @@ swap-case@^1.1.0:
   dependencies:
     lower-case "^1.1.1"
     upper-case "^1.1.1"
+
+symbol-observable@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 table@^3.7.8:
   version "3.8.3"


### PR DESCRIPTION
Notes to the reviewer:

- This has been tested in IE 9, IE 10, iOS simulator, Safari Firefox and Chrome desktop. It would be ideal to give it a quick run in Android Stock browser, but other than that looks fairly promising.
- There are [two](https://github.com/klarna/ui/pull/296/files#diff-b5545cd74975f65dbd1829cc6ded71fc) [new](https://github.com/klarna/ui/pull/296/files#diff-a0b50c48a2153dd6bfce6f5b43e1d7eb) higher-order components added to deal with inline styles for the new ExpandLabel component (Radio only, which is why it doesn’t have a place in the showroom). These two higher-order components **should be moved to [@klarna/higher-order-components](https://github.com/klarna/higher-order-components)**—the reason they are not right now is that it can be done in the next release.
- The extra white layer in the animation that makes the ExpandLabel box disappear is there on purpose. If you have questions about the animation you can also ping @koorochkin 

![chrome mov](https://cloud.githubusercontent.com/assets/381614/22831190/b6eb41fe-efa9-11e6-9295-ca31a7d14041.gif)