### PR TITLE
Add ids to templates

### DIFF
--- a/templates/CenteredForm/index.jsx
+++ b/templates/CenteredForm/index.jsx
@@ -8,6 +8,7 @@ export default function CenteredForm ({
   accept,
   brandVolume,
   cancel,
+  id,
   illustration,
   onAccept,
   onCancel,
@@ -17,11 +18,19 @@ export default function CenteredForm ({
   ...props
 }) {
   const classNames = classNamesBind.bind({...defaultStyles, ...styles})
+  const ids = id
+    ? {
+      centered: `${id}__centered`,
+      content: `${id}__content`,
+      fieldset: `${id}__fieldset`
+    }
+    : {}
 
   return <Centered
     brandVolume={brandVolume}
     onAccept={onAccept}
     onCancel={onCancel}
+    id={ids.centered}
     illustration={illustration}
     labels={{
       accept,
@@ -29,8 +38,11 @@ export default function CenteredForm ({
       summary,
       title
     }}>
-    <div className={classNames('centered-form__content')}>
+    <div
+      id={ids.content}
+      className={classNames('centered-form__content')}>
       <Fieldset
+        id={ids.fieldset}
         {...props}
       />
     </div>

--- a/templates/CenteredSelection/index.jsx
+++ b/templates/CenteredSelection/index.jsx
@@ -11,6 +11,7 @@ const classes = {
 }
 
 export default function CenteredSelection ({
+  id,
   illustration,
   onSelect,
   options,
@@ -20,8 +21,15 @@ export default function CenteredSelection ({
   ...props
 }) {
   const classNames = classNamesBind.bind({...defaultStyles, ...styles})
+  const ids = id
+    ? {
+      centered: `${id}__centered`,
+      selectorDirect: `${id}__selector-direct`
+    }
+    : {}
 
   return <Centered
+    id={ids.centered}
     illustration={illustration}
     labels={{
       summary,
@@ -29,6 +37,7 @@ export default function CenteredSelection ({
     }}
     {...props}>
     <Selector.Direct
+      id={ids.selectorDirect}
       className={classNames(classes.selector)}
       data={options}
       onSelect={onSelect}

--- a/templates/CodePrompt/index.jsx
+++ b/templates/CodePrompt/index.jsx
@@ -33,6 +33,7 @@ function CodePrompt ({
   error,
   errorMessage,
   focus,
+  id,
   label,
   loading,
   message,
@@ -51,8 +52,22 @@ function CodePrompt ({
   const loadingText = loading
   loading = loading || loadingText === ''
   error = errorMessage && error == null ? true : error
+  const ids = id
+    ? {
+      centered: `${id}__centered`,
+      field: `${id}__field`,
+      errorWrapper: `${id}__error-wrapper`,
+      errorParagraph: `${id}__error-paragraph`,
+      errorIcon: `${id}__error__icon`,
+      loadingWrapper: `${id}__loading-wrapper`,
+      loadingIcon: `${id}__loading-icon`,
+      loadingParagraph: `${id}__loading-paragraph`,
+      message: `${id}__message`
+    }
+    : {}
 
   return <Centered
+    id={ids.centered}
     labels={{summary, title}}
     {...props}>
     <Field
@@ -60,6 +75,7 @@ function CodePrompt ({
       disabled={!!loading}
       error={error}
       focus={focus}
+      id={ids.field}
       label={label}
       maxLength={length}
       onBlur={onBlur}
@@ -73,11 +89,15 @@ function CodePrompt ({
       value={value}
     />
 
-    {errorMessage && <div className={classNames(classes.error)}>
+    {errorMessage && <div
+      id={ids.errorWrapper}
+      className={classNames(classes.error)}>
       <Paragraph.Primary
+        id={ids.errorParagraph}
         className={classNames(classes.errorParagraph)}
         color='error'>
         <Cross
+          id={ids.errorIcon}
           className={classNames(classes.errorIcon)}
           color='error'
         />
@@ -85,20 +105,23 @@ function CodePrompt ({
       </Paragraph.Primary>
     </div>}
 
-    {loading && <div className={classNames(classes.loading)}>
+    {loading && <div
+      id={ids.loadingWrapper}
+      className={classNames(classes.loading)}>
       <Loader
+        id={ids.loadingIcon}
         className={classNames(classes.loadingLoader)}
         size='small'
       />
-      {loadingText !== '' && (
-        <Paragraph.Secondary
-          className={classNames(classes.loadingParagraph)}>
-          {loadingText}
-        </Paragraph.Secondary>
-      )}
+      {loadingText !== '' && <Paragraph.Secondary
+        id={ids.loadingParagraph}
+        className={classNames(classes.loadingParagraph)}>
+        {loadingText}
+      </Paragraph.Secondary>}
     </div>}
 
     {message && <Paragraph.Secondary
+      id={ids.message}
       className={classNames(classes.message)}>
       {message}
     </Paragraph.Secondary>}

--- a/templates/ConfirmData/index.jsx
+++ b/templates/ConfirmData/index.jsx
@@ -7,12 +7,26 @@ import defaultStyles from './styles.scss'
 export default function ConfirmData ({
   accept,
   cancel,
+  id,
   info,
   summary,
   title,
   ...props
 }) {
+  const ids = id
+    ? {
+      centered: `${id}__centered`,
+      content: `${id}__content`,
+      textLabel: index => `${id}__text-label__${index}`,
+      value: index => `${id}__value__${index}`
+    }
+    : {
+      textLabel: () => '',
+      value: () => ''
+    }
+
   return <Centered
+    id={ids.centered}
     labels={{
       accept,
       cancel,
@@ -20,12 +34,20 @@ export default function ConfirmData ({
       title
     }}
     {...props}>
-    <div className={defaultStyles['confirm--data__content']}>
+    <div
+      id={ids.content}
+      className={defaultStyles['confirm--data__content']}>
       {info.map(({label, value}, i) => [
-        <TextLabel key={`${i}-label`} margins>
+        <TextLabel
+          id={ids.textLabel(i)}
+          key={`${i}-label`}
+          margins>
           {label}
         </TextLabel>,
-        <Title.Secondary key={`${i}-value`} className={defaultStyles['confirm--data__value']}>
+        <Title.Secondary
+          key={`${i}-value`}
+          id={ids.value(i)}
+          className={defaultStyles['confirm--data__value']}>
           {value}
         </Title.Secondary>
       ])}

--- a/templates/Explanation/index.jsx
+++ b/templates/Explanation/index.jsx
@@ -17,26 +17,41 @@ export default function Explanation ({
   className,
   content,
   legal,
+  id,
   title,
   styles,
   ...props
 }) {
   const classNames = classNamesBind.bind({...defaultStyles, ...styles})
 
+  const ids = id
+    ? {
+      dialogContent: `${id}__dialog-content`,
+      title: `${id}__title`,
+      paragraph: `${id}__paragraph`,
+      legal: `${id}__legal`
+    }
+    : {}
+
   return <Dialog.Content
+    id={ids.dialogContent}
     className={classNames(baseClass, className)}
     {...props}>
     <Title.Primary
+      id={ids.title}
       className={classNames(classes.title)}>
       {title}
     </Title.Primary>
 
     <Paragraph.Primary
+      id={ids.paragraph}
       className={classNames(classes.content)}>
       {content}
     </Paragraph.Primary>
 
-    <Paragraph.Legal className={classNames(classes.legal)}>
+    <Paragraph.Legal
+      id={ids.legal}
+      className={classNames(classes.legal)}>
       {legal}
     </Paragraph.Legal>
   </Dialog.Content>

--- a/templates/FilteredSelection/index.jsx
+++ b/templates/FilteredSelection/index.jsx
@@ -25,6 +25,7 @@ function FilteredSelection ({
   alternative,
   className,
   focus,
+  id,
   label,
   onAlternative,
   onBlur,
@@ -39,22 +40,40 @@ function FilteredSelection ({
   ...props
 }) {
   const classNames = classNamesBind.bind({...defaultStyles, ...styles})
+  const ids = id
+    ? {
+      dialogContent: `${id}__dialog-content`,
+      title: `${id}__title`,
+      summary: `${id}__summary`,
+      fieldset: `${id}__fieldset`,
+      input: `${id}__input`,
+      selectorDirect: `${id}__selector-direct`,
+      alternativeWrapper: `${id}__alternative-wrapper`,
+      alternativeLink: `${id}__alternative-link`
+    }
+    : {}
 
   return <Dialog.Content
+    id={ids.dialogContent}
     className={classNames(baseClass, className)}
     {...props}>
     <Title.Primary
+      id={ids.title}
       className={classNames(classes.title)}>
       {title}
     </Title.Primary>
 
     <Paragraph.Secondary
+      id={ids.summary}
       className={classNames(classes.summary)}>
       {summary}
     </Paragraph.Secondary>
 
-    <Fieldset className={classNames(classes.input)}>
+    <Fieldset
+      id={ids.fieldset}
+      className={classNames(classes.input)}>
       <Input
+        id={ids.input}
         focus={focus}
         icon='search'
         label={label}
@@ -66,14 +85,19 @@ function FilteredSelection ({
     </Fieldset>
 
     <Selector.Direct
+      id={ids.selectorDirect}
       className={classNames(classes.selector)}
       name={title.toLowerCase().replace(/[^a-zA-Z]/g, '')}
       onSelect={onSelect}
       data={options}
     />
 
-    <Paragraph.Primary margins>
-      <Link onClick={onAlternative}>
+    <Paragraph.Primary
+      id={ids.alternativeWrapper}
+      margins>
+      <Link
+        id={ids.alternativeLink}
+        onClick={onAlternative}>
         {alternative}
       </Link>
     </Paragraph.Primary>

--- a/templates/Selection/index.jsx
+++ b/templates/Selection/index.jsx
@@ -16,6 +16,7 @@ const classes = {
 
 export default function Selection ({
   className,
+  id,
   onSelect,
   options,
   summary,
@@ -24,21 +25,33 @@ export default function Selection ({
   ...props
 }) {
   const classNames = classNamesBind.bind({...defaultStyles, ...styles})
+  const ids = id
+    ? {
+      dialogContent: `${id}__dialog-content`,
+      title: `${id}__title`,
+      summary: `${id}__summary`,
+      selectorDirect: `${id}__selector-direct`
+    }
+    : {}
 
   return <Dialog.Content
+    id={ids.dialogContent}
     className={classNames(baseClass, className)}
     {...props}>
     <Title.Primary
+      id={ids.title}
       className={classNames(classes.title)}>
       {title}
     </Title.Primary>
 
     <Paragraph.Primary
+      id={ids.summary}
       className={classNames(classes.summary)}>
       {summary}
     </Paragraph.Primary>
 
     <Selector.Direct
+      id={ids.selectorDirect}
       className={classNames(classes.selector)}
       name={title.toLowerCase().replace(/[^a-zA-Z]/g, '')}
       onSelect={onSelect}

--- a/templates/SingleInputPrompt/index.jsx
+++ b/templates/SingleInputPrompt/index.jsx
@@ -13,6 +13,7 @@ function SingleInputPrompt ({
   focus,
   label,
   legal,
+  id,
   illustration,
   onAccept,
   onBlur,
@@ -25,10 +26,18 @@ function SingleInputPrompt ({
   loading,
   ...props
 }) {
+  const ids = id
+    ? {
+      centered: `${id}__centered`,
+      content: `${id}__content`,
+      input: `${id}__input`
+    }
+    : {}
   return <Centered
     brandVolume={brandVolume}
     onAccept={onAccept}
     onCancel={onCancel}
+    id={ids.centered}
     illustration={illustration}
     loading={loading}
     labels={{
@@ -38,8 +47,11 @@ function SingleInputPrompt ({
       summary,
       title
     }}>
-    <div className={defaultStyles['single-input-prompt__content']}>
+    <div
+      id={ids.content}
+      className={defaultStyles['single-input-prompt__content']}>
       <Input
+        id={ids.input}
         centered
         big
         focus={focus}

--- a/templates/XStepExplanation/index.jsx
+++ b/templates/XStepExplanation/index.jsx
@@ -14,21 +14,36 @@ const classes = {
 const classNames = classNamesBind.bind(defaultStyles)
 
 export default function XStepExplanation ({
+  id,
   accept,
   bullets,
   onAccept,
   title,
   ...props
 }) {
+  const ids = id
+    ? {
+      centered: `${id}__centered`,
+      listWrapper: `${id}__list-wrapper`,
+      listItem: index => `${id}__list-item__${index}`
+    }
+    : {
+      listItem: () => ''
+    }
+
   return <Centered
+    id={ids.centered}
     labels={{
       title,
       accept
     }}
     onAccept={onAccept}
     {...props}>
-    <List.Iconic.Wrapper className={classNames(classes.list)}>
+    <List.Iconic.Wrapper
+      id={ids.listWrapper}
+      className={classNames(classes.list)}>
       {bullets.map(({icon, content}, i) => <List.Iconic.Item
+        id={ids.listItem(i)}
         icon={icon}
         key={i}>
         {content}

--- a/templates/chromes/Centered/index.jsx
+++ b/templates/chromes/Centered/index.jsx
@@ -27,6 +27,7 @@ export default function Centered ({
   children,
   error,
   labels,
+  id,
   illustration,
   loading,
   onAccept,
@@ -37,17 +38,35 @@ export default function Centered ({
   const paragraphs = labels.summary instanceof Array
     ? labels.summary
     : [labels.summary]
+  const ids = id
+    ? {
+      dialogContent: `${id}__dialog-content`,
+      title: `${id}__title`,
+      paragraph: index => `${id}__paragraph__${index}`,
+      accept: `${id}__accept`,
+      cancel: `${id}__cancel`,
+      errorBlock: `${id}__error-block`,
+      errorParagraph: `${id}__error-paragraph`,
+      errorIcon: `${id}__error-icon`,
+      legal: `${id}__legal`
+    } : {
+      paragraph: () => ''
+    }
 
-  return <Dialog.Content className={classNames(baseClass, className)}>
+  return <Dialog.Content
+    id={ids.dialogContent}
+    className={classNames(baseClass, className)}>
     {illustration}
 
     <Title.Primary
+      id={ids.title}
       className={classNames(classes.title)}>
       {labels.title}
     </Title.Primary>
 
     {labels.summary && paragraphs.map((text, index) => (<Paragraph.Secondary
       key={index}
+      id={ids.paragraph(index)}
       className={classNames(classes.paragraphPrimary)}>
       {text}
     </Paragraph.Secondary>))}
@@ -55,6 +74,7 @@ export default function Centered ({
     {children}
 
     {labels.accept && onAccept && <Button.Primary
+      id={ids.accept}
       brandVolume={brandVolume}
       onClick={onAccept}
       loading={loading}
@@ -63,25 +83,32 @@ export default function Centered ({
     </Button.Primary>}
 
     {labels.cancel && onCancel && <Paragraph.Primary
+      id={ids.cancel}
       className={classNames(classes.buttonCancel)}>
       <Link onClick={onCancel}>
         {labels.cancel}
       </Link>
     </Paragraph.Primary>}
 
-    {error && <div className={classNames(classes.error)}>
+    {error && <div
+      id={ids.errorBlock}
+      className={classNames(classes.error)}>
       <Paragraph.Primary
+        id={ids.errorParagraph}
         className={classNames(classes.errorParagraph)}
         color='error'>
         <Cross
           className={classNames(classes.errorIcon)}
           color='error'
+          id={ids.errorIcon}
         />
         {error}
       </Paragraph.Primary>
     </div>}
 
-    {labels.legal && <Paragraph.Legal className={classNames(classes.legal)}>
+    {labels.legal && <Paragraph.Legal
+      id={ids.legal}
+      className={classNames(classes.legal)}>
       {labels.legal}
     </Paragraph.Legal>}
   </Dialog.Content>

--- a/templates/examples/Informative.jsx
+++ b/templates/examples/Informative.jsx
@@ -20,6 +20,7 @@ export default {
       examples: {
         Regular: {
           inline: <Landing
+            id='landing'
             illustration={<DemoIcon />}
             labels={{
               title: 'Welcome to the site',
@@ -235,6 +236,7 @@ export default {
       examples: {
         Regular: {
           inline: <Explanation
+            id='explanation'
             title='This is how the product works'
             content='Chia williamsburg subway tile vaporware, live-edge kinfolk cardigan prism deep v retro seitan.'
             legal='Drinking vinegar unicorn fam pork belly prism. Vegan bicycle rights raclette tofu squid lomo coloring book, meggings marfa PBR&B bushwick. '
@@ -258,6 +260,7 @@ export default {
       examples: {
         Regular: {
           inline: <XStepExplanation
+            id='x-step-explanation'
             title='This is the main feature headline'
             accept='Continue'
             bullets={[
@@ -369,6 +372,7 @@ export default {
       examples: {
         Regular: {
           inline: <ConfirmData
+            id='confirm-data'
             title='Are these your favorite flavors?'
             summary='Street art tattooed live-edge, kitsch four loko hashtag paleo banh mi art party. Viral flexitarian paleo, stumptown dreamcatcher ennui pitchfork bitters squid cornhole roof party tattooed truffaut woke.'
             info={[
@@ -408,6 +412,7 @@ export default {
       examples: {
         Regular: {
           inline: <ReviewData
+            id='review-data'
             title='Review the chosen flavors'
             summary='Street art tattooed live-edge, kitsch four loko hashtag paleo banh mi art party. Viral flexitarian paleo, stumptown dreamcatcher ennui pitchfork bitters squid cornhole roof party tattooed truffaut woke.'
             info={[

--- a/templates/examples/Prompts.jsx
+++ b/templates/examples/Prompts.jsx
@@ -18,6 +18,7 @@ export default {
       examples: {
         Regular: {
           inline: <SingleInputPrompt
+            id='single-input-prompt'
             focus
             illustration={<DemoIcon />}
             title='Welcome to the site'
@@ -102,6 +103,7 @@ export default {
       examples: {
         Regular: {
           inline: <CenteredForm
+            id='centered-form'
             accept='Continue'
             cancel='I’d rather get a car'
             defaultValues={{

--- a/templates/examples/Prompts.jsx
+++ b/templates/examples/Prompts.jsx
@@ -195,6 +195,7 @@ export default {
       examples: {
         Regular: {
           inline: <CodePrompt
+            id='code-prompt'
             defaultValue='123'
             label='The numbers'
             title='Enter the magic numbers'

--- a/templates/examples/Selection.jsx
+++ b/templates/examples/Selection.jsx
@@ -22,6 +22,7 @@ export default {
       examples: {
         Regular: {
           inline: <Selection
+            id='selection'
             title='What option do you prefer?'
             summary='Chia williamsburg subway tile vaporware, live-edge kinfolk cardigan prism deep v retro seitan.'
             options={optionsData}
@@ -50,6 +51,7 @@ export default {
       examples: {
         Regular: {
           inline: <FilteredSelection
+            id='filtered-selection'
             title='Select your flavor'
             summary='Photo booth distillery man bun, bitters stumptown freegan cliche cronut green juice.'
             label='Start typing a flavor'
@@ -100,6 +102,7 @@ export default {
       examples: {
         Regular: {
           inline: <CenteredSelection
+            id='centered-selection'
             illustration={<DemoIcon />}
             title='Select your flavor'
             summary='Photo booth distillery man bun, bitters stumptown freegan cliche cronut green juice.'


### PR DESCRIPTION
This PR adds `id` property support for all available templates. The behavior is that the provided `id` will be used as a prefix in the inner component, for example `${id}__title`. This is the same that was used for individual components.