### PR TITLE
Fix broken IconButton on android

### DIFF
--- a/IconButton/Back/index.jsx
+++ b/IconButton/Back/index.jsx
@@ -7,6 +7,7 @@ import compose from 'ramda/src/compose'
 import {overridable, themeable} from '@klarna/higher-order-components'
 
 const classes = {
+  bgWrapper: 'bg-wrapper',
   iconButton: 'icon-button',
   fill: 'illustration__fill',
   label: 'illustration__label',
@@ -25,25 +26,26 @@ const Back = ({className, color, id, label, left, styles, ...props}) => {
     className={classNames(classes.iconButton, className)}
     id={id}
     {...props}>
-    <svg
-      className={classNames('illustration', 'button', color)}
-      id={ids.illustration}
-      strokeLinecap='round'
-      strokeWidth='2'
-      viewBox='0 0 25 25'
-      height='20px'
-      width='20px'>
-      <path
-        className={classNames(classes.stroke)}
-        d='M15,6l-6.5,6.5l6.5,6.5'
-      />
-    </svg>
-
-    <span
-      className={classNames(classes.label, { left }, color)}
-      id={ids.label}>
-      {label}
-    </span>
+    <div className={classNames(classes.bgWrapper, color)}>
+      <svg
+        className={classNames('illustration', 'button', color)}
+        id={ids.illustration}
+        strokeLinecap='round'
+        strokeWidth='2'
+        viewBox='0 0 25 25'
+        height='20px'
+        width='20px'>
+        <path
+          className={classNames(classes.stroke)}
+          d='M15,6l-6.5,6.5l6.5,6.5'
+        />
+      </svg>
+      <span
+        className={classNames(classes.label, { left }, color)}
+        id={ids.label}>
+        {label}
+      </span>
+    </div>
   </div>
 }
 

--- a/IconButton/Close/index.jsx
+++ b/IconButton/Close/index.jsx
@@ -7,6 +7,7 @@ import compose from 'ramda/src/compose'
 import {overridable, themeable} from '@klarna/higher-order-components'
 
 const classes = {
+  bgWrapper: 'bg-wrapper',
   iconButton: 'icon-button',
   fill: 'illustration__fill',
   label: 'illustration__label',
@@ -25,25 +26,27 @@ const Close = ({className, color, id, label, left, styles, ...props}) => {
     className={classNames(classes.iconButton, className)}
     id={id}
     {...props}>
-    <svg
-      className={classNames('illustration', 'button', color)}
-      id={ids.illustration}
-      strokeLinecap='round'
-      strokeWidth='2'
-      viewBox='0 0 25 25'
-      height='20px'
-      width='20px'>
-      <line x1='6' x2='19' y1='6' y2='19'
-        className={classNames(classes.stroke)} />
-      <line x1='19' x2='6' y1='6' y2='19'
-        className={classNames(classes.stroke)} />
-    </svg>
+    <div className={classNames(classes.bgWrapper, color)}>
+      <svg
+        className={classNames('illustration', 'button', color)}
+        id={ids.illustration}
+        strokeLinecap='round'
+        strokeWidth='2'
+        viewBox='0 0 25 25'
+        height='20px'
+        width='20px'>
+        <line x1='6' x2='19' y1='6' y2='19'
+          className={classNames(classes.stroke)} />
+        <line x1='19' x2='6' y1='6' y2='19'
+          className={classNames(classes.stroke)} />
+      </svg>
 
-    <span
-      className={classNames(classes.label, { left }, color)}
-      id={ids.label}>
-      {label}
-    </span>
+      <span
+        className={classNames(classes.label, { left }, color)}
+        id={ids.label}>
+        {label}
+      </span>
+    </div>
   </div>
 }
 

--- a/IconButton/Hamburger/index.jsx
+++ b/IconButton/Hamburger/index.jsx
@@ -7,6 +7,7 @@ import compose from 'ramda/src/compose'
 import {overridable, themeable} from '@klarna/higher-order-components'
 
 const classes = {
+  bgWrapper: 'bg-wrapper',
   iconButton: 'icon-button',
   fill: 'illustration__fill',
   label: 'illustration__label',
@@ -25,27 +26,29 @@ const Hamburger = ({className, color, id, label, left, styles, ...props}) => {
     className={classNames(classes.iconButton, className)}
     id={id}
     {...props}>
-    <svg
-      className={classNames('illustration', 'button', color)}
-      id={ids.illustration}
-      viewBox='0 0 25 25'
-      strokeLinecap='round'
-      strokeWidth='2'
-      height='20px'
-      width='20px'>
-      {[8, 13, 18].map((y) =>
-        <line
-          className={classNames(classes.stroke)}
-          key={y} x1='6' x2='19' y1={y} y2={y}
-        />
-      )}
-    </svg>
+    <div className={classNames(classes.bgWrapper, color)}>
+      <svg
+        className={classNames('illustration', 'button', color)}
+        id={ids.illustration}
+        viewBox='0 0 25 25'
+        strokeLinecap='round'
+        strokeWidth='2'
+        height='20px'
+        width='20px'>
+        {[8, 13, 18].map((y) =>
+          <line
+            className={classNames(classes.stroke)}
+            key={y} x1='6' x2='19' y1={y} y2={y}
+          />
+        )}
+      </svg>
 
-    <span
-      className={classNames(classes.label, { left }, color)}
-      id={ids.label}>
-      {label}
-    </span>
+      <span
+        className={classNames(classes.label, { left }, color)}
+        id={ids.label}>
+        {label}
+      </span>
+    </div>
   </div>
 }
 

--- a/IconButton/Options/index.jsx
+++ b/IconButton/Options/index.jsx
@@ -7,6 +7,7 @@ import compose from 'ramda/src/compose'
 import {overridable, themeable} from '@klarna/higher-order-components'
 
 const classes = {
+  bgWrapper: 'bg-wrapper',
   iconButton: 'icon-button',
   fill: 'illustration__fill',
   label: 'illustration__label',
@@ -25,25 +26,27 @@ const Options = ({className, color, id, label, left, styles, ...props}) => {
     className={classNames(classes.iconButton, className)}
     id={id}
     {...props}>
-    <svg
-      className={classNames('illustration', 'button', color)}
-      id={ids.illustration}
-      viewBox='0 0 25 25'
-      height='20px'
-      width='20px'>
-      {[7, 13, 19].map((y) =>
-        <circle
-          className={classNames(classes.fill)}
-          key={y} cx='12' cy={y} r='2'
-        />
-      )}
-    </svg>
+    <div className={classNames(classes.bgWrapper, color)}>
+      <svg
+        className={classNames('illustration', 'button', color)}
+        id={ids.illustration}
+        viewBox='0 0 25 25'
+        height='20px'
+        width='20px'>
+        {[7, 13, 19].map((y) =>
+          <circle
+            className={classNames(classes.fill)}
+            key={y} cx='12' cy={y} r='2'
+          />
+        )}
+      </svg>
 
-    <span
-      className={classNames(classes.label, { left }, color)}
-      id={ids.label}>
-      {label}
-    </span>
+      <span
+        className={classNames(classes.label, { left }, color)}
+        id={ids.label}>
+        {label}
+      </span>
+    </div>
   </div>
 }
 

--- a/IconButton/Search/index.jsx
+++ b/IconButton/Search/index.jsx
@@ -7,6 +7,7 @@ import compose from 'ramda/src/compose'
 import {overridable, themeable} from '@klarna/higher-order-components'
 
 const classes = {
+  bgWrapper: 'bg-wrapper',
   iconButton: 'icon-button',
   fill: 'illustration__fill',
   label: 'illustration__label',
@@ -22,27 +23,29 @@ const Search = ({className, color, id, label, left, styles, ...props}) => {
     } : {}
 
   return <div className={classNames(classes.iconButton, className)} {...props}>
-    <svg
-      className={classNames('illustration', 'button', color)}
-      id={ids.illustration}
-      viewBox='0 0 25 25'
-      strokeWidth='2'
-      strokeLinecap='round'
-      height='20px'
-      width='20px'>
-      <circle
-        className={classNames(classes.stroke)}
-        cx={10.5} cy={10.5} r={5.5} />
-      <line
-        className={classNames(classes.stroke)}
-        x1={15} x2={19.2} y1={15} y2={19.2} />
-    </svg>
+    <div className={classNames(classes.bgWrapper, color)}>
+      <svg
+        className={classNames('illustration', 'button', color)}
+        id={ids.illustration}
+        viewBox='0 0 25 25'
+        strokeWidth='2'
+        strokeLinecap='round'
+        height='20px'
+        width='20px'>
+        <circle
+          className={classNames(classes.stroke)}
+          cx={10.5} cy={10.5} r={5.5} />
+        <line
+          className={classNames(classes.stroke)}
+          x1={15} x2={19.2} y1={15} y2={19.2} />
+      </svg>
 
-    <span
-      className={classNames(classes.label, { left }, color)}
-      id={ids.label}>
-      {label}
-    </span>
+      <span
+        className={classNames(classes.label, { left }, color)}
+        id={ids.label}>
+        {label}
+      </span>
+    </div>
   </div>
 }
 

--- a/IconButton/Select/index.jsx
+++ b/IconButton/Select/index.jsx
@@ -6,6 +6,7 @@ import defaultStyles from '../styles.scss'
 import withDisplayName from '../withDisplayName'
 
 const classes = {
+  bgWrapper: 'bg-wrapper',
   iconButton: 'icon-button',
   fill: 'illustration__fill',
   label: 'illustration__label',
@@ -25,25 +26,27 @@ const Select = ({className, color, id, label, left, styles, ...props}) => {
     className={classNames(classes.iconButton, className)}
     id={id}
     {...props}>
-    <svg
-      className={classNames('illustration', 'button', color)}
-      id={ids.illustration}
-      strokeLinecap='round'
-      strokeWidth='2'
-      viewBox='0 0 21 21'
-      height='20px'
-      width='20px'>
-      <path
-        className={classNames(classes.stroke)}
-        d='M9,6l4,4l-4,4'
-      />
-    </svg>
+    <div className={classNames(classes.bgWrapper, color)}>
+      <svg
+        className={classNames('illustration', 'button', color)}
+        id={ids.illustration}
+        strokeLinecap='round'
+        strokeWidth='2'
+        viewBox='0 0 21 21'
+        height='20px'
+        width='20px'>
+        <path
+          className={classNames(classes.stroke)}
+          d='M9,6l4,4l-4,4'
+        />
+      </svg>
 
-    <span
-      className={classNames(classes.label, classes.labelLight, { left }, color)}
-      id={ids.label}>
-      {label}
-    </span>
+      <span
+        className={classNames(classes.label, classes.labelLight, { left }, color)}
+        id={ids.label}>
+        {label}
+      </span>
+    </div>
   </div>
 }
 

--- a/IconButton/styles.scss
+++ b/IconButton/styles.scss
@@ -34,6 +34,7 @@
   }
 
   .illustration {
+    pointer-events: none;
     &.button {
       @include illustration(map-get($colors, klarna-blue));
 

--- a/IconButton/styles.scss
+++ b/IconButton/styles.scss
@@ -10,8 +10,8 @@
   width: ($grid * 4);
 
   .bg-wrapper {
-    border-radius: 100%;
     border: ($grid * 2) solid transparent;
+    border-radius: 100%;
     left: 0;
     margin: -10px;
     position: absolute;

--- a/IconButton/styles.scss
+++ b/IconButton/styles.scss
@@ -3,22 +3,42 @@
 
 .icon-button {
   cursor: pointer;
+  display: inline-block;
   height: ($grid * 4);
   overflow: visible;
   position: relative;
   width: ($grid * 4);
+
+  .bg-wrapper {
+    border-radius: 100%;
+    border: ($grid * 2) solid transparent;
+    left: 0;
+    margin: -10px;
+    position: absolute;
+    top: 0;
+
+    &:active {
+      background: map-get($colors, blue-active-background);
+      border-color: map-get($colors, blue-active-background);
+
+      &.gray {
+        background: map-get($colors, grey-active-background);
+        border-color: map-get($colors, grey-active-background);
+      }
+
+      &.inverse {
+        background: map-get($colors, klarna-blue-hover);
+        border-color: map-get($colors, klarna-blue-hover);
+      }
+    }
+  }
 
   .illustration {
     &.button {
       @include illustration(map-get($colors, klarna-blue));
 
       background: transparent;
-      border: ($grid * 2) solid transparent;
-      border-radius: 100%;
-      height: ($grid * 4);
-      margin: ($grid * -2);
       transition: stroke .2s ease, fill .2s ease, color .2s ease;
-      width: ($grid * 4);
 
       &.gray {
         @include illustration(map-get($colors, grey-text));
@@ -55,25 +75,7 @@
       }
     }
   }
-
-  &:active {
-    .illustration.button {
-      background: map-get($colors, blue-active-background);
-      border-color: map-get($colors, blue-active-background);
-
-      &.gray {
-        background: map-get($colors, grey-active-background);
-        border-color: map-get($colors, grey-active-background);
-      }
-
-      &.inverse {
-        background: map-get($colors, klarna-blue-hover);
-        border-color: map-get($colors, klarna-blue-hover);
-      }
-    }
-  }
 }
-
 
 .illustration__label {
   @include typography(map-get($font-sizes, label-desktop), semi-bold);


### PR DESCRIPTION
Improves the IconButton on Android 4.x devices. Apparently, having `padding` on an `<svg>` causes a lot of problems on older Android devices. I found this by spending much of my sanity in the Android emulator, tweaking the various css properties for `IconButton`.

As a small bonus, the `:active` hint (the circle with the background color) now also works on IE 10/11, by adding `pointer-events` to the svg to let the click event fall-through to the divs behind it. However it still only works if you click the actual icon, not the text. I assume this has to do with how the `:active` pseudo selector is implemented. But, I think this is a minor improvement so I kept it.

![android4iconbutton](https://cloud.githubusercontent.com/assets/569742/23018116/1a3d7636-f43d-11e6-8a23-04a64217dffc.png)
