### PR TITLE
Fix Cannot read property 'focus' of undefined

### DIFF
--- a/Radio/index.jsx
+++ b/Radio/index.jsx
@@ -34,16 +34,14 @@ const classes = {
 
 class Radio extends Component {
   componentDidMount () {
-    if (
-      this.props.focus &&
-      this.refs[this.props.focus] &&
-      getActiveElement(document) !== this.refs[this.props.focus]
-    ) {
-      this.refs[this.props.focus].focus()
-    }
+    this.applyFocus()
   }
 
   componentDidUpdate () {
+    this.applyFocus()
+  }
+
+  applyFocus () {
     if (
       this.props.focus &&
       this.refs[this.props.focus] &&

--- a/Radio/index.jsx
+++ b/Radio/index.jsx
@@ -36,6 +36,7 @@ class Radio extends Component {
   componentDidMount () {
     if (
       this.props.focus &&
+      this.refs[this.props.focus] &&
       getActiveElement(document) !== this.refs[this.props.focus]
     ) {
       this.refs[this.props.focus].focus()
@@ -45,6 +46,7 @@ class Radio extends Component {
   componentDidUpdate () {
     if (
       this.props.focus &&
+      this.refs[this.props.focus] &&
       getActiveElement(document) !== this.refs[this.props.focus]
     ) {
       this.refs[this.props.focus].focus()


### PR DESCRIPTION
We saw this issue recently popping up in our Sentry logs.

It can happen if the prop in not correctly set. This change makes the component more defensive about the value of `this.props.focus`.

I've also extracted an `applyFocus` function to be shared by both `componentDidMount` and `componentDidUpdate` hooks.

The actual fix can be seen at 7d2525e.