### PR TITLE
Button loading width

### DIFF
--- a/Button/Primary/index.jsx
+++ b/Button/Primary/index.jsx
@@ -50,9 +50,15 @@ function Primary ({
     ? parseColor(customize.textColor).rgb
     : 'white'
 
-  const loadingOrContent = loading
-    ? <Loader inline color={loaderColor} />
-    : (success ? '✔' : children)
+  const content = (success ? '✔' : children)
+
+  const loadingOrContent =
+    <span>
+      <div className={loading ? classNames('visibilityHidden') : ''}>
+        {content}
+      </div>
+      {loading ? <Loader inline color={loaderColor} /> : null}
+    </span>
 
   const customizations = customize
     ? {

--- a/Button/Secondary/index.jsx
+++ b/Button/Secondary/index.jsx
@@ -55,9 +55,13 @@ function Secondary ({
 
   const content = (success ? '✔' : children)
 
-  const loadingOrContent = loading
-    ? <Loader inline color={loaderColor} />
-    : content
+  const loadingOrContent =
+    <span>
+      <div className={loading ? classNames('visibilityHidden') : ''}>
+        {content}
+      </div>
+      {loading ? <Loader inline color={loaderColor} /> : null}
+    </span>
 
   const customizations = customize
     ? {

--- a/Button/Tertiary/index.jsx
+++ b/Button/Tertiary/index.jsx
@@ -55,9 +55,13 @@ function Tertiary (props) {
 
   const content = (success ? '✔' : children)
 
-  const loadingOrContent = loading
-    ? <Loader inline color={loaderColor} />
-    : content
+  const loadingOrContent =
+    <span>
+      <div className={loading ? classNames('visibilityHidden') : ''}>
+        {content}
+      </div>
+      {loading ? <Loader inline color={loaderColor} /> : null}
+    </span>
 
   const customizations = customize
     ? {

--- a/Button/styles.scss
+++ b/Button/styles.scss
@@ -15,6 +15,17 @@
     );
   }
 
+  .visibilityHidden {
+    visibility: hidden;
+    height: 0;
+
+    .button__price {
+      float: none;
+      padding-left: 0;
+      margin-left: 0;
+    }
+  }
+
   .button--primary__darkening {
     background: black;
     bottom: 0;
@@ -58,6 +69,17 @@
     @include button__price(
       $border-color: map-get($colors, klarna-blue)
     );
+  }
+
+  .visibilityHidden {
+    visibility: hidden;
+    height: 0;
+
+    .button__price {
+      float: none;
+      padding-left: 0;
+      margin-left: 0;
+    }
   }
 
   &:hover,
@@ -149,6 +171,18 @@
       $border-color: map-get($colors, klarna-blue)
     );
   }
+
+  .visibilityHidden {
+    visibility: hidden;
+    height: 0;
+
+    .button__price {
+      float: none;
+      padding-left: 0;
+      margin-left: 0;
+    }
+  }
+
 
   &:hover,
   &:focus {

--- a/Button/styles.scss
+++ b/Button/styles.scss
@@ -1,6 +1,19 @@
 @import '../css/settings';
 @import '../css/mixins/index';
 
+@mixin loading-or-success() {
+  .visibilityHidden {
+    visibility: hidden;
+    height: 0;
+
+    .button__price {
+      float: none;
+      padding-left: 0;
+      margin-left: 0;
+    }
+  }
+}
+
 .button--primary {
   @include button(
     $background: map-get($colors, klarna-blue),
@@ -15,16 +28,7 @@
     );
   }
 
-  .visibilityHidden {
-    visibility: hidden;
-    height: 0;
-
-    .button__price {
-      float: none;
-      padding-left: 0;
-      margin-left: 0;
-    }
-  }
+  @include loading-or-success();
 
   .button--primary__darkening {
     background: black;
@@ -71,16 +75,7 @@
     );
   }
 
-  .visibilityHidden {
-    visibility: hidden;
-    height: 0;
-
-    .button__price {
-      float: none;
-      padding-left: 0;
-      margin-left: 0;
-    }
-  }
+  @include loading-or-success();
 
   &:hover,
   &:focus {
@@ -172,17 +167,7 @@
     );
   }
 
-  .visibilityHidden {
-    visibility: hidden;
-    height: 0;
-
-    .button__price {
-      float: none;
-      padding-left: 0;
-      margin-left: 0;
-    }
-  }
-
+  @include loading-or-success();
 
   &:hover,
   &:focus {

--- a/Button/styles.scss
+++ b/Button/styles.scss
@@ -3,13 +3,13 @@
 
 @mixin loading-or-success() {
   .visibilityHidden {
-    visibility: hidden;
     height: 0;
+    visibility: hidden;
 
     .button__price {
       float: none;
-      padding-left: 0;
       margin-left: 0;
+      padding-left: 0;
     }
   }
 }


### PR DESCRIPTION
until now when a button move to 'loading' or 'success' mode we have to manually set his size to avoid a weird 'jump' in the ui..... no more!
tnx @omriyariv for the css solution

before:
![button jump](https://cloud.githubusercontent.com/assets/16437281/23210814/e2e6fdb8-f907-11e6-9d71-fb369ade91c3.gif)

after:
![good button](https://cloud.githubusercontent.com/assets/16437281/23210818/eaa31b54-f907-11e6-9ff0-bba2bbb2c1ff.gif)


if you have better idea pls ping me