### PR TITLE
Improvements to Radio visible options

### DIFF
--- a/Radio/example.jsx
+++ b/Radio/example.jsx
@@ -97,6 +97,12 @@ export default {
         visibleOptions={1}
       />,
 
+      'Partially collapsed with options that fit the configuration': <Radio
+        options={optionsWithContent}
+        expandLabel='Show me all the options'
+        visibleOptions={50}
+      />,
+
       Controlled: <Radio
         focus='sit'
         name='radio'

--- a/Radio/example.jsx
+++ b/Radio/example.jsx
@@ -97,6 +97,12 @@ export default {
         visibleOptions={1}
       />,
 
+      'Completely collapsed': <Radio
+        options={optionsWithContent}
+        expandLabel='Show me all the options'
+        visibleOptions={0}
+      />,
+
       'Partially collapsed with options that fit the configuration': <Radio
         options={optionsWithContent}
         expandLabel='Show me all the options'

--- a/Radio/example.jsx
+++ b/Radio/example.jsx
@@ -105,11 +105,18 @@ export default {
         value='ipsum'
       />,
 
-      'Partially collapsed & controlled': <Radio
+      'Partially collapsed & controlled (not expanded)': <Radio
         options={optionsWithContent}
         expandLabel='Show me all the options'
         visibleOptions={1}
         fullyExpanded={false}
+      />,
+
+      'Partially collapsed & controlled (expanded)': <Radio
+        options={optionsWithContent}
+        expandLabel='Show me all the options'
+        visibleOptions={1}
+        fullyExpanded
       />,
 
       Borderless: <Radio

--- a/Radio/index.jsx
+++ b/Radio/index.jsx
@@ -82,10 +82,10 @@ class Radio extends Component {
     const descriptionStyle = customize ? { color: customize.textSecondaryColor } : undefined
 
     const optionLists = {
-      visible: visibleOptions
+      visible: typeof visibleOptions !== 'undefined'
         ? options.slice(0, visibleOptions)
         : options,
-      collapsed: visibleOptions
+      collapsed: typeof visibleOptions !== 'undefined'
         ? options.slice(visibleOptions)
         : []
     }

--- a/Radio/index.jsx
+++ b/Radio/index.jsx
@@ -217,7 +217,7 @@ class Radio extends Component {
           ]
         })}
 
-        {visibleOptions && <Collapsible
+        {optionLists.collapsed.length > 0 && <Collapsible
           onStartFPSCollection={onStartFPSCollection}
           onEndFPSCollection={onEndFPSCollection}
           lowFPS={lowFPS}

--- a/Radio/index.jsx
+++ b/Radio/index.jsx
@@ -90,9 +90,9 @@ class Radio extends Component {
         : []
     }
 
-    const isExpanded = fullyExpanded || (
-      value && optionLists.collapsed.find(({key}) => key === value) != null
-    )
+    const isExpanded = fullyExpanded ||
+      (optionLists.collapsed.length === 0) ||
+      (value && optionLists.collapsed.find(({key}) => key === value) != null)
 
     return (
       <div


### PR DESCRIPTION
- Better document the `fullyExpanded` prop;
- Don't render the expand label if the number of options can fit the `visibleOptions` configuration;
- Allow the Radio to be fully collapsed.

![screen shot 2017-02-22 at 17 03 30](https://cloud.githubusercontent.com/assets/6001/23220001/de6cf42c-f920-11e6-827e-37c320b8589e.png)
