### PR TITLE
Make the default BoxSelector overridable

### DIFF
--- a/BoxSelector/index.jsx
+++ b/BoxSelector/index.jsx
@@ -60,4 +60,4 @@ BoxSelector.propTypes = {
   layout: PropTypes.oneOf(['auto', 'horizontal', 'vertical'])
 }
 
-export default overridable(defaultStyles, BoxSelector)
+export default overridable(defaultStyles)(BoxSelector)

--- a/BoxSelector/index.jsx
+++ b/BoxSelector/index.jsx
@@ -3,7 +3,6 @@ import classNamesBind from 'classnames/bind'
 import {
   overridable
 } from '@klarna/higher-order-components'
-import compose from 'ramda/src/compose'
 import Horizontal from './Horizontal'
 import Vertical from './Vertical'
 import defaultStyles from './styles.scss'
@@ -61,6 +60,4 @@ BoxSelector.propTypes = {
   layout: PropTypes.oneOf(['auto', 'horizontal', 'vertical'])
 }
 
-export default compose(
-  overridable(defaultStyles)
-)(BoxSelector)
+export default overridable(defaultStyles, BoxSelector)

--- a/BoxSelector/index.jsx
+++ b/BoxSelector/index.jsx
@@ -1,5 +1,9 @@
 import React, {Component, PropTypes} from 'react'
 import classNamesBind from 'classnames/bind'
+import {
+  overridable
+} from '@klarna/higher-order-components'
+import compose from 'ramda/src/compose'
 import Horizontal from './Horizontal'
 import Vertical from './Vertical'
 import defaultStyles from './styles.scss'
@@ -47,6 +51,8 @@ class BoxSelector extends Component {
   }
 }
 
+BoxSelector.displayName = 'BoxSelector'
+
 BoxSelector.defaultProps = {
   layout: 'auto'
 }
@@ -55,4 +61,6 @@ BoxSelector.propTypes = {
   layout: PropTypes.oneOf(['auto', 'horizontal', 'vertical'])
 }
 
-export default BoxSelector
+export default compose(
+  overridable(defaultStyles)
+)(BoxSelector)


### PR DESCRIPTION
The default BoxSelector component switches between the Horizontal and the Vertical component depending on the screen size. But since it was not overridable, even the nested components were overridable, the custom designs are not propagated properly.

I tested, it looks that only the `overridable` high-order component is needed, it works fine without `themeable` or `uncontrolled`.