### PR TITLE
Support link in button

### DIFF
--- a/Button/Primary/index.jsx
+++ b/Button/Primary/index.jsx
@@ -69,7 +69,7 @@ function Primary ({
     } : {}
 
   return (
-    <button
+    <a
       className={cls}
       disabled={loading || success || disabled}
       id={id}
@@ -92,7 +92,7 @@ function Primary ({
         />
       ]
       : loadingOrContent}
-    </button>
+    </a>
   )
 }
 

--- a/Button/Primary/index.jsx
+++ b/Button/Primary/index.jsx
@@ -28,12 +28,14 @@ function Primary ({
   className,
   customize,
   disabled,
+  href,
   id,
   loading,
   size,
   style,
   styles,
   success,
+  target,
   ...remainingProps
 }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
@@ -74,8 +76,34 @@ function Primary ({
       label: `${id}__label`
     } : {}
 
-  return (
-    <a
+  const markup = href || target
+    ? <a
+      className={cls}
+      disabled={loading || success || disabled}
+      id={id}
+      href={href}
+      target={target}
+      style={{
+        ...customizations,
+        ...style
+      }}
+      {...remainingProps}>
+      {customize ? [
+        <span
+          key={1}
+          className={classNames(classes.label)}
+          id={ids.label}>
+          {loadingOrContent}
+        </span>,
+        loading || disabled || <div key={2}
+          className={classNames(classes.darkening)}
+          id={ids.darkening}
+          style={{borderRadius: customize.borderRadius}}
+        />
+      ]
+      : loadingOrContent}
+    </a>
+    : <button
       className={cls}
       disabled={loading || success || disabled}
       id={id}
@@ -98,8 +126,9 @@ function Primary ({
         />
       ]
       : loadingOrContent}
-    </a>
-  )
+    </button>
+
+  return markup
 }
 
 Primary.displayName = 'Button.Primary'
@@ -120,12 +149,14 @@ Primary.propTypes = {
     borderRadius: PropTypes.string.isRequired,
     textColor: PropTypes.string.isRequired
   }),
-  id: PropTypes.string,
-  size: PropTypes.oneOf(sizes),
-  loading: PropTypes.bool,
-  success: PropTypes.bool,
   disabled: PropTypes.bool,
-  styles: PropTypes.object
+  href: PropTypes.string,
+  id: PropTypes.string,
+  loading: PropTypes.bool,
+  size: PropTypes.oneOf(sizes),
+  styles: PropTypes.object,
+  success: PropTypes.bool,
+  target: PropTypes.string
 }
 
 export default compose(

--- a/Button/Secondary/index.jsx
+++ b/Button/Secondary/index.jsx
@@ -29,12 +29,14 @@ function Secondary ({
   className,
   customize,
   disabled,
+  href,
   id,
   loading,
   size,
   style,
   styles,
   success,
+  target,
   ...props
 }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
@@ -78,8 +80,46 @@ function Secondary ({
       labelAlt: `${id}__label--alt`
     } : {}
 
-  return (
-    <button
+  const markup = href || target
+    ? <a
+      className={cls}
+      disabled={isDisabled}
+      href={href}
+      id={id}
+      style={{
+        ...customizations,
+        ...style
+      }}
+      target={target}
+      {...props}>
+      {
+        customize ? [
+          loading || <div key={1}
+            className={classNames(classes.darkening)}
+            id={ids.darkening}
+            style={customize && {
+              borderRadius: `${parseInt(customize.borderRadius, 10) - 1}px`
+            }}
+          />,
+          <div
+            key={2}
+            id={ids.label}
+            className={classNames(classes.label)}>
+            {loadingOrContent}
+            {
+              isDisabled || <span
+                className={classNames(classes.labelAlt)}
+                id={ids.labelAlt}
+                title={content}
+                style={{color: customize.textColor}}
+              />
+            }
+          </div>
+        ]
+        : loadingOrContent
+      }
+    </a>
+    : <button
       className={cls}
       disabled={isDisabled}
       id={id}
@@ -115,7 +155,8 @@ function Secondary ({
         : loadingOrContent
       }
     </button>
-  )
+
+  return markup
 }
 
 Secondary.displayName = 'Button.Secondary'
@@ -136,12 +177,14 @@ Secondary.propTypes = {
     borderRadius: PropTypes.string.isRequired,
     textColor: PropTypes.string.isRequired
   }),
-  id: PropTypes.string,
-  size: PropTypes.oneOf(sizes),
-  loading: PropTypes.bool,
-  success: PropTypes.bool,
   disabled: PropTypes.bool,
-  styles: PropTypes.object
+  href: PropTypes.string,
+  id: PropTypes.string,
+  loading: PropTypes.bool,
+  size: PropTypes.oneOf(sizes),
+  styles: PropTypes.object,
+  success: PropTypes.bool,
+  target: PropTypes.string
 }
 
 export default compose(

--- a/Button/Tertiary/index.jsx
+++ b/Button/Tertiary/index.jsx
@@ -30,12 +30,14 @@ function Tertiary (props) {
     className,
     customize,
     disabled,
+    href,
     id,
     loading,
     size,
     style,
     styles,
     success,
+    target,
     ...remainingProps } = props
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
@@ -78,8 +80,41 @@ function Tertiary (props) {
       labelAlt: `${id}__label--alt`
     } : {}
 
-  return (
-    <button
+  const markup = href || target
+    ? <a
+      className={cls}
+      disabled={isDisabled}
+      href={href}
+      style={{
+        ...customizations,
+        ...style
+      }}
+      target={target}
+      {...remainingProps}>
+      {
+        customize ? [
+          loading || <div key={1}
+            className={classNames(classes.darkening)}
+            style={customize && {
+              borderRadius: `${parseInt(customize.borderRadius, 10) - 1}px`
+            }}
+          />,
+          <div key={2} className={classNames(classes.label)}>
+            {loadingOrContent}
+            {
+              isDisabled || <span
+                className={classNames(classes.labelAlt)}
+                id={ids.labelAlt}
+                title={content}
+                style={{color: customize.textColor}}
+              />
+            }
+          </div>
+        ]
+        : loadingOrContent
+      }
+    </a>
+    : <button
       className={cls}
       disabled={isDisabled}
       style={{
@@ -110,7 +145,8 @@ function Tertiary (props) {
         : loadingOrContent
       }
     </button>
-  )
+
+  return markup
 }
 
 Tertiary.displayName = 'Button.Tertiary'
@@ -131,12 +167,14 @@ Tertiary.propTypes = {
     borderRadius: PropTypes.string.isRequired,
     textColor: PropTypes.string.isRequired
   }),
-  id: PropTypes.string,
-  size: PropTypes.oneOf(sizes),
-  loading: PropTypes.bool,
-  success: PropTypes.bool,
   disabled: PropTypes.bool,
-  styles: PropTypes.object
+  href: PropTypes.string,
+  id: PropTypes.string,
+  loading: PropTypes.bool,
+  size: PropTypes.oneOf(sizes),
+  styles: PropTypes.object,
+  success: PropTypes.bool,
+  target: PropTypes.string
 }
 
 export default compose(

--- a/Button/example.jsx
+++ b/Button/example.jsx
@@ -118,7 +118,7 @@ export default {
       type: LIVE,
 
       examples: {
-        Small: <Button.Primary size='small'>Click me!</Button.Primary>,
+        Small: <Button.Primary href='http://google.com' size='small'>Click me!</Button.Primary>,
         Regular: <Button.Primary>Click me!</Button.Primary>,
         Big: <Button.Primary size='big'>Click me!</Button.Primary>,
         Custom: <Button.Primary

--- a/Button/example.jsx
+++ b/Button/example.jsx
@@ -118,12 +118,17 @@ export default {
       type: LIVE,
 
       examples: {
-        Small: <Button.Primary href='http://google.com' size='small'>Click me!</Button.Primary>,
+        Small: <Button.Primary size='small'>Click me!</Button.Primary>,
         Regular: <Button.Primary>Click me!</Button.Primary>,
         Big: <Button.Primary size='big'>Click me!</Button.Primary>,
         Custom: <Button.Primary
           customize={{textColor: '#F9FF3C', borderRadius: '15px', backgroundColor: '#3500C8'}}>
           Beautiful!
+        </Button.Primary>,
+        'As a link': <Button.Primary
+          href='http://klarna.com'
+          target='_blank'>
+          Open the homepage
         </Button.Primary>,
         'With price small': <Button.Primary size='small'>
           Pay now!
@@ -190,6 +195,11 @@ export default {
           customize={{textColor: '#F9FF3C', borderRadius: '15px', backgroundColor: '#3500C8'}}>
           Beautiful!
         </Button.Secondary>,
+        'As a link': <Button.Secondary
+          href='http://klarna.com'
+          target='_blank'>
+          Open the homepage
+        </Button.Secondary>,
         'High brand volume': (
           <div>
             <Button.Secondary brandVolume='high'>
@@ -234,6 +244,11 @@ export default {
         Custom: <Button.Tertiary
           customize={{textColor: '#F9FF3C', borderRadius: '15px', backgroundColor: '#3500C8'}}>
           Beautiful!
+        </Button.Tertiary>,
+        'As a link': <Button.Tertiary
+          href='http://klarna.com'
+          target='_blank'>
+          Open the homepage
         </Button.Tertiary>,
         Disabled: <Button.Tertiary disabled>Click me!</Button.Tertiary>,
         Loading: <Button.Tertiary loading>Click me!</Button.Tertiary>,

--- a/css/mixins/button.scss
+++ b/css/mixins/button.scss
@@ -9,6 +9,7 @@
   box-sizing: border-box;
   color: $text-color;
   cursor: pointer;
+  display: inline-block;
   height: ($grid * 10);
   line-height: ($grid * 10) - ($grid * .4);
   outline: none;


### PR DESCRIPTION
`Button` components (`Primary`, `Secondary` and `Tertiary`) now support the `href` and `target` props that will cause them to render as `<a>`.

<img width="802" alt="screen shot 2017-02-27 at 11 03 46" src="https://cloud.githubusercontent.com/assets/381614/23357068/817fe4e4-fcdc-11e6-83a0-c0616ef7121c.png">

Fixes https://github.com/klarna/ui/issues/321