### PR TITLE
Remove leftpad in radio for mobile

### DIFF
--- a/BoxSelector/index.jsx
+++ b/BoxSelector/index.jsx
@@ -6,7 +6,7 @@ import {
 import Horizontal from './Horizontal'
 import Vertical from './Vertical'
 import defaultStyles from './styles.scss'
-import {MOBILE_MAX_WIDTH} from '../settings'
+import { isMobile } from '../lib/device'
 
 const baseClass = 'box-selector'
 
@@ -36,8 +36,7 @@ class BoxSelector extends Component {
 
       case 'auto':
       default:
-        const currentWidth = window.innerWidth || document.body.clientWidth
-        const wide = currentWidth >= MOBILE_MAX_WIDTH
+        const wide = !isMobile()
 
         return <div
           className={classNames(baseClass)}

--- a/Radio/Option/index.js
+++ b/Radio/Option/index.js
@@ -29,7 +29,6 @@ export default ({
     disabled,
     aside,
     content,
-    leftPad,
     ...restOfProps
   } = option
 
@@ -146,8 +145,7 @@ export default ({
         collapsed={isDisabled || !singleOption && key !== value}>
         <div
           style={{
-            ...finalStyles.base.content,
-            ...(leftPad && !singleOption ? finalStyles.leftPad.content : {})
+            ...finalStyles.base.content
           }}
           id={ids.content}>
           {content}

--- a/Radio/Option/styles.js
+++ b/Radio/Option/styles.js
@@ -11,8 +11,8 @@ export default {
   base: {
     content: {
       paddingBottom: grid(4),
-      paddingLeft: grid(4),
-      paddingRight: grid(4)
+      paddingLeft: isMobile() ? grid(4) : grid(9.8),
+      paddingRight: isMobile() ? grid(4) : grid(9.8)
     },
     aside: {
       display: 'table-cell',
@@ -122,12 +122,6 @@ export default {
   selected: {
     header: {
       cursor: 'auto'
-    }
-  },
-  leftPad: {
-    content: {
-      paddingLeft: isMobile() ? grid(4) : grid(9.8),
-      paddingRight: isMobile() ? grid(4) : grid(9.8)
     }
   }
 }

--- a/Radio/Option/styles.js
+++ b/Radio/Option/styles.js
@@ -126,7 +126,8 @@ export default {
   },
   leftPad: {
     content: {
-      paddingLeft: isMobile() ? grid(4) : grid(9.8)
+      paddingLeft: isMobile() ? grid(4) : grid(9.8),
+      paddingRight: isMobile() ? grid(4) : grid(9.8)
     }
   }
 }

--- a/Radio/Option/styles.js
+++ b/Radio/Option/styles.js
@@ -5,6 +5,7 @@ import {BORDER_RADIUS} from '../../settings/themes/default/assorted'
 import * as fontFamilies from '../../settings/fontFamilies'
 import * as fontSizes from '../../settings/fontSizes'
 import * as fontWeights from '../../settings/fontWeights'
+import { isMobile } from '../../lib/device'
 
 export default {
   base: {
@@ -125,7 +126,7 @@ export default {
   },
   leftPad: {
     content: {
-      paddingLeft: grid(9.8)
+      paddingLeft: isMobile() ? grid(4) : grid(9.8)
     }
   }
 }

--- a/Radio/example.js
+++ b/Radio/example.js
@@ -7,6 +7,7 @@ import BoxSelector from '../BoxSelector'
 import Dropdown from '../Dropdown'
 import Subtitle from '../Subtitle'
 
+import { isMobile } from '../lib/device'
 import grid from '../settings/grid'
 import * as palette from '../settings/palette'
 import * as fontFamilies from '../settings/fontFamilies'
@@ -33,8 +34,7 @@ const optionsWithContent = [
     aside: card,
     content: <Paragraph.Secondary style={{marginBottom: -10}}>
       Offal man braid XOXO DIY, pok pok tbh poke post-ironic neutra try-hard small batch.
-    </Paragraph.Secondary>,
-    leftPad: true
+    </Paragraph.Secondary>
   },
 
   {
@@ -92,8 +92,8 @@ const fullStylesOverride = {
     base: {
       content: {
         paddingBottom: grid(6),
-        paddingLeft: grid(6),
-        paddingRight: grid(6)
+        paddingLeft: isMobile() ? grid(6) : grid(9.8),
+        paddingRight: isMobile() ? grid(6) : grid(9.8)
       },
       aside: {
         display: 'table-cell',
@@ -138,13 +138,7 @@ const fullStylesOverride = {
       header: {
         cursor: 'crosshair'
       }
-    },
-    leftPad: {
-      content: {
-        paddingLeft: grid(9.8)
-      }
     }
-
   },
   expandLabel: {
     base: {
@@ -300,8 +294,7 @@ export default {
           aside: card,
           content: <Paragraph.Secondary condensed>
             Offal man braid XOXO DIY, pok pok tbh poke post-ironic neutra try-hard small batch.
-          </Paragraph.Secondary>,
-          leftPad: true
+          </Paragraph.Secondary>
         }]}
       />,
 

--- a/Showroom/examples/compositions/UncontrolledForm.jsx
+++ b/Showroom/examples/compositions/UncontrolledForm.jsx
@@ -26,8 +26,7 @@ const optionsWithContent = [
     </svg>,
     content: <Paragraph.Secondary condensed>
       Offal man braid XOXO DIY, pok pok tbh poke post-ironic neutra try-hard small batch.
-    </Paragraph.Secondary>,
-    leftPad: true
+    </Paragraph.Secondary>
   },
 
   {

--- a/Showroom/examples/compositions/UniqueIds.jsx
+++ b/Showroom/examples/compositions/UniqueIds.jsx
@@ -544,8 +544,7 @@ import * as Button from '@klarna/ui/Button'`,
               </svg>,
               content: <Paragraph.Secondary condensed>
                 Offal man braid XOXO DIY, pok pok tbh poke post-ironic neutra try-hard small batch.
-              </Paragraph.Secondary>,
-              leftPad: true
+              </Paragraph.Secondary>
             },
 
             {

--- a/Theme/example.jsx
+++ b/Theme/example.jsx
@@ -30,8 +30,7 @@ const optionsWithContent = [
     description: 'Lorem Ipsum is simply dummy.',
     content: <Paragraph.Secondary condensed>
       Offal man braid XOXO DIY, pok pok tbh poke post-ironic neutra try-hard small batch.
-    </Paragraph.Secondary>,
-    leftPad: true
+    </Paragraph.Secondary>
   },
 
   {

--- a/lib/device.js
+++ b/lib/device.js
@@ -1,0 +1,12 @@
+import { MOBILE_MAX_WIDTH } from '../settings'
+
+/**
+ * Based on window width determines mobile
+ *
+ * This should be refactored into a HOC attaching to context
+ * for listening to window resize events
+ */
+export const isMobile = () => {
+  var currentWidth = window.innerWidth || document.body.clientWidth;
+  return currentWidth < MOBILE_MAX_WIDTH;
+}

--- a/lib/device.js
+++ b/lib/device.js
@@ -7,6 +7,6 @@ import { MOBILE_MAX_WIDTH } from '../settings'
  * for listening to window resize events
  */
 export const isMobile = () => {
-  var currentWidth = window.innerWidth || document.body.clientWidth;
-  return currentWidth < MOBILE_MAX_WIDTH;
+  var currentWidth = window.innerWidth || document.body.clientWidth
+  return currentWidth < MOBILE_MAX_WIDTH
 }


### PR DESCRIPTION
Removes `leftPad` toggle prop for adding/removing left padding in the `Radio` component, since it invites for inconsistency in the presentation of `Radio` content.

This will, depending on device screen size vary left & right padding between 4 or 9.8 grid multiplier.

Would be a good idea to create a Component listening to 'resize'/'onresize' events depending on browser, and populate these values to `context` for better handling in responsive contexts.  