### PR TITLE
Slightly better fail for long button labels in responsive context

### DIFF
--- a/Button/styles.scss
+++ b/Button/styles.scss
@@ -14,6 +14,15 @@
   }
 }
 
+a.button--primary {
+  display: table;
+
+  > span {
+    display: table-cell;
+    vertical-align: middle;
+  }
+}
+
 .button--primary {
   @include button(
     $background: map-get($colors, klarna-blue),
@@ -58,6 +67,15 @@
     .button--primary__darkening {
       opacity: .3;
     }
+  }
+}
+
+a.button--secondary {
+  display: table;
+
+  > span {
+    display: table-cell;
+    vertical-align: middle;
   }
 }
 
@@ -148,6 +166,15 @@
         }
       }
     }
+  }
+}
+
+a.button--tertiary {
+  display: table;
+
+  > span {
+    display: table-cell;
+    vertical-align: middle;
   }
 }
 

--- a/css/mixins/button.scss
+++ b/css/mixins/button.scss
@@ -11,7 +11,7 @@
   cursor: pointer;
   display: inline-block;
   height: ($grid * 10);
-  line-height: ($grid * 10) - ($grid * .4);
+  line-height: inherit;
   outline: none;
   padding: 0 ($grid * 9);
   position: relative;


### PR DESCRIPTION
Not the most graceful solution. Don't know how much I'll break. 

Gives an alternative approach to how badly buttons fail in a responsive context for multi-word labels.

We could perhaps build on this?