### PR TITLE
Fix customize override order

### DIFF
--- a/BoxSelector/Horizontal/index.jsx
+++ b/BoxSelector/Horizontal/index.jsx
@@ -232,13 +232,13 @@ export default compose(
       onChange: () => value => value
     }
   }),
-  themeable((customizations, props) => ({
+  themeable((customizations, {customize}) => ({
     customize: {
-      ...props.customize,
       borderColor: customizations.color_border,
       borderColorSelected: customizations.color_border_selected,
       borderRadius: customizations.radius_border,
-      labelColor: customizations.color_text
+      labelColor: customizations.color_text,
+      ...customize
     }
   })),
   overridable(defaultStyles),

--- a/BoxSelector/Vertical/index.jsx
+++ b/BoxSelector/Vertical/index.jsx
@@ -232,13 +232,13 @@ export default compose(
       onChange: () => value => value
     }
   }),
-  themeable((customizations, props) => ({
+  themeable((customizations, {customize}) => ({
     customize: {
-      ...props.customize,
       borderColor: customizations.color_border,
       borderColorSelected: customizations.color_border_selected,
       borderRadius: customizations.radius_border,
-      labelColor: customizations.color_text
+      labelColor: customizations.color_text,
+      ...customize
     }
   })),
   overridable(defaultStyles),

--- a/Button/Primary/index.jsx
+++ b/Button/Primary/index.jsx
@@ -163,10 +163,10 @@ export default compose(
   (component) => (withPropsFromContext(component, ['brandVolume'])),
   themeable((customizations, { customize }) => ({
     customize: {
-      ...customize,
       backgroundColor: customizations.color_button,
       borderRadius: customizations.radius_border,
-      textColor: customizations.color_button_text
+      textColor: customizations.color_button_text,
+      ...customize
     }
   })),
   overridable(defaultStyles)

--- a/Button/Secondary/index.jsx
+++ b/Button/Secondary/index.jsx
@@ -167,10 +167,10 @@ export default compose(
   (component) => (withPropsFromContext(component, ['brandVolume'])),
   themeable((customizations, { customize }) => ({
     customize: {
-      ...customize,
       backgroundColor: customizations.color_button,
       borderRadius: customizations.radius_border,
-      textColor: customizations.color_button_text
+      textColor: customizations.color_button_text,
+      ...customize
     }
   })),
   overridable(defaultStyles)

--- a/Button/Tertiary/index.jsx
+++ b/Button/Tertiary/index.jsx
@@ -183,10 +183,10 @@ export default compose(
   (component) => (withPropsFromContext(component, ['brandVolume'])),
   themeable((customizations, { customize }) => ({
     customize: {
-      ...customize,
       backgroundColor: customizations.color_button,
       borderRadius: customizations.radius_border,
-      textColor: customizations.color_button_text
+      textColor: customizations.color_button_text,
+      ...customize
     }
   })),
   overridable(defaultStyles)

--- a/Checklist/index.jsx
+++ b/Checklist/index.jsx
@@ -104,11 +104,11 @@ ChecklistItem.propTypes = {
 }
 
 export const Item = compose(
-  themeable((customizations, props) => ({
+  themeable((customizations, {customize}) => ({
     customize: {
-      ...props.customize,
       strokeColor: customizations.color_details,
-      textColor: customizations.color_text
+      textColor: customizations.color_text,
+      ...customize
     }
   })),
   overridable(defaultStyles)

--- a/Dialog/index.jsx
+++ b/Dialog/index.jsx
@@ -49,10 +49,10 @@ DialogMain.propTypes = {
 }
 
 export const Main = compose(
-  themeable((customizations, props) => ({
+  themeable((customizations, {customize}) => ({
     customize: {
-      ...props.customize,
-      borderRadius: customizations.radius_border
+      borderRadius: customizations.radius_border,
+      ...customize
     }
   })),
   overridable(defaultStyles)

--- a/Dropdown/index.jsx
+++ b/Dropdown/index.jsx
@@ -268,14 +268,14 @@ export default compose(
       onChange: () => e => e.target.value
     }
   }),
-  themeable((customizations, props) => ({
+  themeable((customizations, {customize}) => ({
     customize: {
-      ...props.customize,
       borderColor: customizations.color_border,
       borderColorSelected: customizations.color_border_selected,
       borderRadius: customizations.radius_border,
       labelColor: customizations.color_text_secondary,
-      selectedColor: customizations.color_text
+      selectedColor: customizations.color_text,
+      ...customize
     }
   })),
   overridable(defaultStyles),

--- a/Field/index.jsx
+++ b/Field/index.jsx
@@ -293,14 +293,14 @@ export default compose(
       onChange: () => e => e.target.value
     }
   }),
-  themeable((customizations, props) => ({
+  themeable((customizations, {customize}) => ({
     customize: {
-      ...props.customize,
       borderColor: customizations.color_border,
       borderColorSelected: customizations.color_border_selected,
       borderRadius: customizations.radius_border,
       labelColor: customizations.color_text_secondary,
-      inputColor: customizations.color_text
+      inputColor: customizations.color_text,
+      ...customize
     }
   })),
   overridable(defaultStyles),

--- a/Link/index.jsx
+++ b/Link/index.jsx
@@ -54,10 +54,10 @@ Link.propTypes = {
 }
 
 export default compose(
-  themeable((customizations, props) => ({
+  themeable((customizations, {customize}) => ({
     customize: {
-      ...props.customize,
-      textColor: customizations.color_link
+      textColor: customizations.color_link,
+      ...customize
     }
   })),
   overridable(defaultStyles)

--- a/List/Item/index.jsx
+++ b/List/Item/index.jsx
@@ -53,10 +53,10 @@ Item.propTypes = {
 }
 
 export default compose(
-  themeable((customizations, props) => ({
+  themeable((customizations, {style}) => ({
     style: {
-      ...props.style,
-      color: customizations.color_text
+      color: customizations.color_text,
+      ...style
     }
   })),
   overridable(defaultStyles)

--- a/Paragraph/Primary/index.jsx
+++ b/Paragraph/Primary/index.jsx
@@ -57,10 +57,10 @@ Primary.propTypes = {
 }
 
 export default compose(
-  themeable(isThemeable((customizations, props) => ({
+  themeable(isThemeable((customizations, {style}) => ({
     style: {
-      ...props.style,
-      color: customizations.color_text
+      color: customizations.color_text,
+      ...style
     }
   }))),
   overridable(defaultStyles)

--- a/Paragraph/Secondary/index.jsx
+++ b/Paragraph/Secondary/index.jsx
@@ -57,10 +57,10 @@ Secondary.propTypes = {
 }
 
 export default compose(
-  themeable(isThemeable((customizations, props) => ({
+  themeable(isThemeable((customizations, {style}) => ({
     style: {
-      ...props.style,
-      color: customizations.color_text_secondary
+      color: customizations.color_text_secondary,
+      ...style
     }
   }))),
   overridable(defaultStyles)

--- a/Radio/index.js
+++ b/Radio/index.js
@@ -257,14 +257,14 @@ export default compose(
       onChange: () => value => value
     }
   }),
-  themeable((customizations, props) => ({
+  themeable((customizations, {customize}) => ({
     customize: {
-      ...props.customize,
       backgroundColor: customizations.color_checkbox,
       bulletColor: customizations.color_checkbox_checkmark,
       borderRadius: customizations.radius_border,
       textPrimaryColor: customizations.color_text,
-      textSecondaryColor: customizations.color_text_secondary
+      textSecondaryColor: customizations.color_text_secondary,
+      ...customize
     }
   })),
   overridable(defaultStyles),

--- a/RadioMark/index.js
+++ b/RadioMark/index.js
@@ -81,11 +81,11 @@ RadioMark.defaultProps = {
 }
 
 export default compose(
-  themeable((customizations, props) => ({
+  themeable((customizations, {customize}) => ({
     customize: {
-      ...props.customize,
       backgroundColor: customizations.color_checkbox,
-      bulletColor: customizations.color_checkbox_checkmark
+      bulletColor: customizations.color_checkbox_checkmark,
+      ...customize
     }
   }))
 )(RadioMark)

--- a/Selector/Input/index.jsx
+++ b/Selector/Input/index.jsx
@@ -213,13 +213,13 @@ const SelectorInput = React.createClass({
 })
 
 export default compose(
-  themeable((customizations, props) => ({
+  themeable((customizations, {customize}) => ({
     customize: {
-      ...props.customize,
       borderColor: customizations.color_border,
       borderColorSelected: customizations.color_border_selected,
       labelColor: customizations.color_text_secondary,
-      inputColor: customizations.color_text
+      inputColor: customizations.color_text,
+      ...customize
     }
   })),
   overridable(defaultStyles)

--- a/Selector/Options/index.jsx
+++ b/Selector/Options/index.jsx
@@ -182,13 +182,13 @@ export default compose(
     }
   }),
   uniqueName,
-  themeable((customizations, props) => ({
+  themeable((customizations, {customize}) => ({
     customize: {
-      ...props.customize,
       borderColor: customizations.color_border,
       bulletColor: customizations.color_checkbox_checkmark,
       labelColor: customizations.color_text_secondary,
-      labelColorSelected: customizations.color_text
+      labelColorSelected: customizations.color_text,
+      ...customize
     }
   })),
   overridable(defaultStyles)

--- a/Subtitle/index.jsx
+++ b/Subtitle/index.jsx
@@ -57,10 +57,10 @@ Subtitle.propTypes = {
 }
 
 export default compose(
-  themeable(isThemeable((customizations, props) => ({
+  themeable(isThemeable((customizations, {style}) => ({
     style: {
-      ...props.style,
-      color: customizations.color_header
+      color: customizations.color_header,
+      ...style
     }
   }))),
   overridable(defaultStyles)

--- a/Switch/Checkbox/index.jsx
+++ b/Switch/Checkbox/index.jsx
@@ -207,13 +207,13 @@ export default compose(
       onChange: () => field => field
     }
   }),
-  themeable((customizations, props) => ({
+  themeable((customizations, {customize}) => ({
     customize: {
-      ...props.customize,
       backgroundColor: customizations.color_checkbox,
       bulletColor: customizations.color_checkbox_checkmark,
       textColor: customizations.color_text,
-      borderColorSelected: customizations.color_border_selected
+      borderColorSelected: customizations.color_border_selected,
+      ...customize
     }
   })),
   overridable(defaultStyles),

--- a/Switch/Toggle/index.jsx
+++ b/Switch/Toggle/index.jsx
@@ -272,12 +272,12 @@ export default compose(
       onChange: () => field => field
     }
   }),
-  themeable((customizations, props) => ({
+  themeable((customizations, {customize}) => ({
     customize: {
-      ...props.customize,
       backgroundColor: customizations.color_checkbox,
       bulletColor: customizations.color_checkbox_checkmark,
-      textColor: customizations.color_text
+      textColor: customizations.color_text,
+      ...customize
     }
   })),
   overridable(defaultStyles),

--- a/Title/Primary/index.jsx
+++ b/Title/Primary/index.jsx
@@ -63,10 +63,10 @@ Primary.propTypes = {
 }
 
 export default compose(
-  themeable(isThemeable((customizations, props) => ({
+  themeable(isThemeable((customizations, {style}) => ({
     style: {
-      ...props.style,
-      color: customizations.color_header
+      color: customizations.color_header,
+      ...style
     }
   }))),
   overridable(defaultStyles)

--- a/Title/Secondary/index.jsx
+++ b/Title/Secondary/index.jsx
@@ -59,10 +59,10 @@ Secondary.propTypes = {
 }
 
 export default compose(
-  themeable(isThemeable((customizations, props) => ({
+  themeable(isThemeable((customizations, {style}) => ({
     style: {
-      ...props.style,
-      color: customizations.color_header
+      color: customizations.color_header,
+      ...style
     }
   }))),
   overridable(defaultStyles)


### PR DESCRIPTION
From:

```javascript
  themeable((customizations, { customize }) => ({
    customize: {
      ...customize,
      backgroundColor: customizations.color_button,
      borderRadius: customizations.radius_border,
      textColor: customizations.color_button_text
    }
  }))
```

To:

```javascript
  themeable((customizations, { customize }) => ({
    customize: {
      backgroundColor: customizations.color_button,
      borderRadius: customizations.radius_border,
      textColor: customizations.color_button_text,
      ...customize
    }
  }))
```
