### PR TITLE
Move react-hot-loader to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "parse-color": "1.0.0",
     "react-component-queries": "^2.1.1",
     "react-context-props": "^0.1.4",
+    "react-hot-loader": "^3.0.0-beta.6",
     "react-sizeme": "^2.2.0"
   },
   "devDependencies": {
@@ -67,7 +68,6 @@
     "react-addons-test-utils": "^15.4.0",
     "react-dom": "15.4.0",
     "react-element-to-jsx-string": "^4.1.0",
-    "react-hot-loader": "^3.0.0-beta.6",
     "react-maskedinput": "^3.3.1",
     "react-motion": "^0.4.2",
     "react-syntax-highlighter": "^2.2.0",


### PR DESCRIPTION
Our tests are breaking because of missing plugin.