### PR TITLE
Add overflow to regular (non-animated) Collapsible component

### DIFF
--- a/Collapsible/index.js
+++ b/Collapsible/index.js
@@ -43,7 +43,8 @@ export default class Collapsible extends Component {
       style={{
         display: 'block',
         height: collapsed ? minimumHeight : 'auto',
-        opacity: collapsed ? 0 : 1
+        opacity: collapsed ? 0 : 1,
+        overflow: collapsed ? 'hidden' : 'auto'
       }}>
       {children}
     </div>


### PR DESCRIPTION
If you tab through the options inside the `Radio` component, the options will become blank and noninteractive in Chrome. This seems to be caused by the layout change of the `Collapsible` component. The fix is to put `overflow: hidden` to it when collapsed. It's only an issue for the non-animated variant, as the animated already specifies `overflow`.