### PR TITLE
Use same padding on both left and right side of vertical BoxSelector content

### DIFF
--- a/BoxSelector/Vertical/styles.scss
+++ b/BoxSelector/Vertical/styles.scss
@@ -23,9 +23,7 @@ $highlightTransitionEasing: cubic-bezier(.31,.09,.24,1);
   cursor: pointer;
   display: block;
   line-height: ($grid * 5);
-  padding-bottom: ($grid * 2.4);
-  padding-left: ($grid * 4);
-  padding-top: ($grid * 2.4);
+  padding: ($grid * 2.4) ($grid * 4);
 }
 
 .box-selector--vertical__cell.is-hovered,


### PR DESCRIPTION
On narrow devices the text inside the vertical BoxSelector content can get really close to the right border instead of wrapping onto a new line. This is because there is no right padding on the content element. The right padding should be the same as the left one in order for the text to wrap properly.