### PR TITLE
Add peer dependencies to externals

### DIFF
--- a/webpack.config.build.js
+++ b/webpack.config.build.js
@@ -15,7 +15,14 @@ module.exports = {
     filename: '[name]-built.js',
     library: 'kui',
     libraryTarget: 'umd',
-    umdNamedDefine: true
+    umdNamedDefine: true,
+    externals: [
+      'html2react',
+      'prop-types',
+      'ramda',
+      'react',
+      'react-motion'
+    ]
   },
   resolve: {
     modules: [

--- a/webpack.config.build.js
+++ b/webpack.config.build.js
@@ -15,15 +15,15 @@ module.exports = {
     filename: '[name]-built.js',
     library: 'kui',
     libraryTarget: 'umd',
-    umdNamedDefine: true,
-    externals: [
-      'html2react',
-      'prop-types',
-      'ramda',
-      'react',
-      'react-motion'
-    ]
+    umdNamedDefine: true
   },
+  externals: [
+    'html2react',
+    'prop-types',
+    'ramda',
+    'react',
+    'react-motion'
+  ],
   resolve: {
     modules: [
       path.resolve('./'),


### PR DESCRIPTION
This is to avoid bundling a separate copy of React in this build, which
causes problems like this:
https://facebook.github.io/react/warnings/refs-must-have-owner.html

With this change it is possible to load kui without changing the webpack.config.js of projects that wish to use this library, and avoid having to add dependencies like `node-sass` (which has its own host of problems with having to run `npm rebuild node-sass` time and again).

Wonderful UI library you are open sourcing btw 🎉 