### PR TITLE
Update to new React standards even from dependencies

### DIFF
--- a/BoxSelector/Horizontal/index.jsx
+++ b/BoxSelector/Horizontal/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import classNamesBind from 'classnames/bind'
 import {
@@ -23,36 +23,15 @@ const classes = {
 
 const findIndexOfOptionKey = (options) => (key) => options.findIndex((option) => option.key === key)
 
-const Horizontal = React.createClass({
-  displayName: 'BoxSelector.Horizontal',
+class Horizontal extends Component {
+  constructor () {
+    super()
 
-  propTypes: {
-    options: PropTypes.arrayOf(PropTypes.shape({
-      key: PropTypes.string.isRequired,
-      content: PropTypes.isRequired
-    })).isRequired,
-    className: PropTypes.string,
-    customize: PropTypes.shape({
-      borderColor: PropTypes.string.isRequired,
-      borderColorSelected: PropTypes.string.isRequired,
-      borderRadius: PropTypes.string.isRequired,
-      labelColor: PropTypes.string.isRequired
-    }),
-    focus: PropTypes.string,
-    id: PropTypes.string,
-    onBlur: PropTypes.func,
-    onChange: PropTypes.func,
-    onFocus: PropTypes.func,
-    name: PropTypes.string.isRequired,
-    value: PropTypes.string
-  },
-
-  getInitialState () {
-    return {
+    this.state = {
       hover: undefined,
       previouslySelected: undefined
     }
-  },
+  }
 
   componentDidMount () {
     if (
@@ -61,7 +40,7 @@ const Horizontal = React.createClass({
     ) {
       this.refs[this.props.focus].focus()
     }
-  },
+  }
 
   componentWillReceiveProps (props) {
     if (props.value !== undefined) {
@@ -69,7 +48,7 @@ const Horizontal = React.createClass({
         previouslySelected: this.props.value
       })
     }
-  },
+  }
 
   componentDidUpdate () {
     if (
@@ -78,11 +57,11 @@ const Horizontal = React.createClass({
     ) {
       this.refs[this.props.focus].focus()
     }
-  },
+  }
 
   getSelectedLabel (key) {
     return this.refs[`${key || this.props.value}-label`]
-  },
+  }
 
   render () {
     const {
@@ -204,7 +183,30 @@ const Horizontal = React.createClass({
       </div>
     </div>)
   }
-})
+}
+
+Horizontal.propTypes = {
+  options: PropTypes.arrayOf(PropTypes.shape({
+    key: PropTypes.string.isRequired,
+    content: PropTypes.isRequired
+  })).isRequired,
+  className: PropTypes.string,
+  customize: PropTypes.shape({
+    borderColor: PropTypes.string.isRequired,
+    borderColorSelected: PropTypes.string.isRequired,
+    borderRadius: PropTypes.string.isRequired,
+    labelColor: PropTypes.string.isRequired
+  }),
+  focus: PropTypes.string,
+  id: PropTypes.string,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  name: PropTypes.string.isRequired,
+  value: PropTypes.string
+}
+
+Horizontal.displayName = 'BoxSelector.Horizontal'
 
 const hoverStartHandler = (component) => (id) => component.setState({ hover: id })
 const hoverEndHandler = (component) => () => component.setState({hover: undefined})

--- a/BoxSelector/Vertical/index.jsx
+++ b/BoxSelector/Vertical/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import classNamesBind from 'classnames/bind'
 import {
@@ -23,36 +23,15 @@ const classes = {
 
 const findIndexOfOptionKey = (options) => (key) => options.findIndex((option) => option.key === key)
 
-const Vertical = React.createClass({
-  displayName: 'BoxSelector.Vertical',
+class Vertical extends Component {
+  constructor () {
+    super()
 
-  propTypes: {
-    options: PropTypes.arrayOf(PropTypes.shape({
-      key: PropTypes.string.isRequired,
-      content: PropTypes.isRequired
-    })).isRequired,
-    className: PropTypes.string,
-    customize: PropTypes.shape({
-      borderColor: PropTypes.string.isRequired,
-      borderColorSelected: PropTypes.string.isRequired,
-      borderRadius: PropTypes.string.isRequired,
-      labelColor: PropTypes.string.isRequired
-    }),
-    focus: PropTypes.string,
-    id: PropTypes.string,
-    onBlur: PropTypes.func,
-    onChange: PropTypes.func,
-    onFocus: PropTypes.func,
-    name: PropTypes.string.isRequired,
-    value: PropTypes.string
-  },
-
-  getInitialState () {
-    return {
+    this.state = {
       hover: undefined,
       previouslySelected: undefined
     }
-  },
+  }
 
   componentDidMount () {
     if (
@@ -61,7 +40,7 @@ const Vertical = React.createClass({
     ) {
       this.refs[this.props.focus].focus()
     }
-  },
+  }
 
   componentWillReceiveProps (props) {
     if (props.value !== undefined) {
@@ -69,7 +48,7 @@ const Vertical = React.createClass({
         previouslySelected: this.props.value
       })
     }
-  },
+  }
 
   componentDidUpdate () {
     if (
@@ -78,11 +57,11 @@ const Vertical = React.createClass({
     ) {
       this.refs[this.props.focus].focus()
     }
-  },
+  }
 
   getSelectedLabel (key) {
     return this.refs[`${key || this.props.value}-label`]
-  },
+  }
 
   render () {
     const {
@@ -204,7 +183,30 @@ const Vertical = React.createClass({
       </div>
     </div>)
   }
-})
+}
+
+Vertical.displayName = 'BoxSelector.Vertical'
+
+Vertical.propTypes = {
+  options: PropTypes.arrayOf(PropTypes.shape({
+    key: PropTypes.string.isRequired,
+    content: PropTypes.isRequired
+  })).isRequired,
+  className: PropTypes.string,
+  customize: PropTypes.shape({
+    borderColor: PropTypes.string.isRequired,
+    borderColorSelected: PropTypes.string.isRequired,
+    borderRadius: PropTypes.string.isRequired,
+    labelColor: PropTypes.string.isRequired
+  }),
+  focus: PropTypes.string,
+  id: PropTypes.string,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  name: PropTypes.string.isRequired,
+  value: PropTypes.string
+}
 
 const hoverStartHandler = (component) => (id) => component.setState({ hover: id })
 const hoverEndHandler = (component) => () => component.setState({hover: undefined})

--- a/Button/Primary/index.jsx
+++ b/Button/Primary/index.jsx
@@ -163,7 +163,7 @@ Primary.propTypes = {
 }
 
 export default compose(
-  (component) => (withPropsFromContext(component, ['brandVolume'])),
+  withPropsFromContext(['brandVolume']),
   themeable((customizations, { customize }) => ({
     customize: {
       backgroundColor: customizations.color_button,

--- a/Button/Secondary/index.jsx
+++ b/Button/Secondary/index.jsx
@@ -167,7 +167,7 @@ Secondary.propTypes = {
 }
 
 export default compose(
-  (component) => (withPropsFromContext(component, ['brandVolume'])),
+  withPropsFromContext(['brandVolume']),
   themeable((customizations, { customize }) => ({
     customize: {
       backgroundColor: customizations.color_button,

--- a/Button/Tertiary/index.jsx
+++ b/Button/Tertiary/index.jsx
@@ -187,7 +187,7 @@ Tertiary.propTypes = {
 }
 
 export default compose(
-  (component) => (withPropsFromContext(component, ['brandVolume'])),
+  withPropsFromContext(['brandVolume']),
   themeable((customizations, { customize }) => ({
     customize: {
       backgroundColor: customizations.color_button,

--- a/Dialog/example.jsx
+++ b/Dialog/example.jsx
@@ -71,7 +71,7 @@ import * as Button from '@klarna/ui/Button'`,
 
     examples: {
       Regular: {
-        live: <Example />,
+        live: <DialogExample />,
         code: `<Dialog.Overlay show>
   <Dialog.Main>
     <Dialog.Icon>

--- a/Dialog/example.jsx
+++ b/Dialog/example.jsx
@@ -1,18 +1,18 @@
-import React from 'react'
+import React, {Component} from 'react'
 import * as Button from '../Button'
 import * as Dialog from '../Dialog'
 import { Close } from '../IconButton'
 import { Title, Paragraph, Subtitle } from '../Text'
 import { MANUAL } from '../Showroom/variationTypes'
 
-const Example = React.createClass({
-  displayName: 'DialogExample',
+class DialogExample extends Component {
+  constructor () {
+    super()
 
-  getInitialState () {
-    return {
+    this.state = {
       open: false
     }
-  },
+  }
 
   render () {
     const close = () => this.setState({ open: false })
@@ -54,7 +54,7 @@ const Example = React.createClass({
       </div>
     )
   }
-})
+}
 
 export default {
   title: 'Dialog',

--- a/Dropdown/index.jsx
+++ b/Dropdown/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {Component} from 'react'
 import classNamesBind from 'classnames/bind'
 import PropTypes from 'prop-types'
 import defaultStyles from './styles.scss'
@@ -25,84 +25,40 @@ const classes = {
   select: `${baseClass}__select`
 }
 
-const Dropdown = React.createClass({
-  displayName: 'Dropdown',
+class Dropdown extends Component {
+  constructor () {
+    super()
 
-  getInitialState () {
-    return {
+    this.state = {
       hover: false
     }
-  },
-
-  getDefaultProps () {
-    return {
-      fieldTooltip: '',
-      loading: false,
-      onChange: function () {},
-      mouseflowExclude: false,
-      ...inlinedIcon.defaultProps,
-      ...fieldStates.defaultProps,
-      ...stacking.position.defaultProps,
-      ...handleKeyDown.defaultProps,
-      ...stacking.size.defaultProps
-    }
-  },
-
-  propTypes: {
-    customize: PropTypes.shape({
-      borderColor: PropTypes.string.isRequired,
-      borderColorSelected: PropTypes.string.isRequired,
-      borderRadius: PropTypes.string.isRequired,
-      labelColor: PropTypes.string.isRequired,
-      selectedColor: PropTypes.string.isRequired
-    }),
-    focus: PropTypes.bool,
-    id: PropTypes.string,
-    label: PropTypes.string,
-    loading: PropTypes.bool,
-    mouseflowExclude: PropTypes.bool,
-    onBlur: PropTypes.func,
-    onChange: PropTypes.func,
-    onClick: PropTypes.func,
-    onFocus: PropTypes.func,
-    options: PropTypes.arrayOf(PropTypes.shape({
-      label: PropTypes.string.isRequired,
-      key: PropTypes.any.isRequired
-    })),
-    styles: PropTypes.object,
-    value: PropTypes.any,
-    ...inlinedIcon.propTypes,
-    ...fieldStates.propTypes,
-    ...handleKeyDown.propTypes,
-    ...stacking.position.propTypes,
-    ...stacking.size.propTypes
-  },
+  }
 
   componentDidMount () {
     if (this.props.focus && getActiveElement(document) !== this.refs.select) {
       this.refs.select.focus()
     }
-  },
+  }
 
   componentDidUpdate () {
     if (this.props.focus && getActiveElement(document) !== this.refs.select) {
       this.refs.select.focus()
     }
-  },
+  }
 
   onMouseEnter () {
     this.setState({
       ...this.state,
       hover: true
     })
-  },
+  }
 
   onMouseLeave () {
     this.setState({
       ...this.state,
       hover: false
     })
-  },
+  }
 
   render () {
     const {
@@ -255,7 +211,49 @@ const Dropdown = React.createClass({
       </div>
     )
   }
-})
+}
+
+Dropdown.defaultProps = {
+  fieldTooltip: '',
+  loading: false,
+  onChange: function () {},
+  mouseflowExclude: false,
+  ...inlinedIcon.defaultProps,
+  ...fieldStates.defaultProps,
+  ...stacking.position.defaultProps,
+  ...handleKeyDown.defaultProps,
+  ...stacking.size.defaultProps
+}
+
+Dropdown.propTypes = {
+  customize: PropTypes.shape({
+    borderColor: PropTypes.string.isRequired,
+    borderColorSelected: PropTypes.string.isRequired,
+    borderRadius: PropTypes.string.isRequired,
+    labelColor: PropTypes.string.isRequired,
+    selectedColor: PropTypes.string.isRequired
+  }),
+  focus: PropTypes.bool,
+  id: PropTypes.string,
+  label: PropTypes.string,
+  loading: PropTypes.bool,
+  mouseflowExclude: PropTypes.bool,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onClick: PropTypes.func,
+  onFocus: PropTypes.func,
+  options: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    key: PropTypes.any.isRequired
+  })),
+  styles: PropTypes.object,
+  value: PropTypes.any,
+  ...inlinedIcon.propTypes,
+  ...fieldStates.propTypes,
+  ...handleKeyDown.propTypes,
+  ...stacking.position.propTypes,
+  ...stacking.size.propTypes
+}
 
 const onMouseEnter = (component) => () =>
   component.setState({

--- a/Field/example.jsx
+++ b/Field/example.jsx
@@ -96,7 +96,7 @@ export default {
 
         'With customizations': {
           live: <Field
-            customize={{ borderColor: '#3500C8', borderColorSelected: '#3500C8', borderRadius: '15px', inputColor: 'green', labelColor: 'red' }}
+            customize={{ borderColor: '#3500C8', borderColorSelected: 'yellow', borderRadius: '15px', inputColor: 'green', labelColor: 'red' }}
             label='Favorite color'
             defaultValue='Purple'
           />,

--- a/Field/example.jsx
+++ b/Field/example.jsx
@@ -148,6 +148,7 @@ import ReactTextMask from 'react-text-mask'`,
           live: <Field
             label='Credit card number'
             Input={ReactTextMask}
+            type='tel'
             mask={[
               /\d/, /\d/, /\d/, /\d/, ' ',
               /\d/, /\d/, /\d/, /\d/, ' ',

--- a/Field/example.jsx
+++ b/Field/example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Field, { icons } from '../Field'
 import Fieldset from '../Fieldset'
-import ReactMaskedInput from 'react-maskedinput'
+import ReactTextMask from 'react-text-mask'
 import { LIVE, LIVE_WIDE, MANUAL } from '../Showroom/variationTypes'
 
 export default {
@@ -140,22 +140,32 @@ export default {
     {
       title: 'Override',
       require: `import Field from '@klarna/ui/Field'
-import ReactMaskedInput from 'react-maskedinput'`,
+import ReactTextMask from 'react-text-mask'`,
       type: MANUAL,
 
       examples: {
         'Masked credit card field': {
           live: <Field
             label='Credit card number'
-            Input={ReactMaskedInput}
-            mask='1111 1111 1111 1111'
+            Input={ReactTextMask}
+            mask={[
+              /\d/, /\d/, /\d/, /\d/, ' ',
+              /\d/, /\d/, /\d/, /\d/, ' ',
+              /\d/, /\d/, /\d/, /\d/, ' ',
+              /\d/, /\d/, /\d/, /\d/
+            ]}
             placeholder=' '
           />,
 
           code: `<Field
   label='Credit card number'
-  Input={ReactMaskedInput}
-  mask='1111 1111 1111 1111'
+  Input={ReactTextMask}
+  mask={[
+    /\d/, /\d/, /\d/, /\d/, ' ',
+    /\d/, /\d/, /\d/, /\d/, ' ',
+    /\d/, /\d/, /\d/, /\d/, ' ',
+    /\d/, /\d/, /\d/, /\d/
+  ]}
   placeholder=' '
 />`
         }

--- a/Field/index.jsx
+++ b/Field/index.jsx
@@ -57,25 +57,30 @@ class Field extends Component {
   }
 
   componentDidMount () {
-    if (this.props.focus && getActiveElement(document) !== this.refs.input) {
-      this.refs.input.focus()
+    const input = this.rootDOMElement.querySelector('input')
+
+    if (input && this.props.focus && getActiveElement(document) !== input) {
+      input.focus()
     }
 
-    this.refs.input.addEventListener &&
-    this.refs.input.addEventListener('animationstart', (e) => {
-      switch (e.animationName) {
-        case defaultStyles.onAutoFillStart:
-          return this.onAutoFillStart()
+    if (input &&input.addEventListener) {
+      input.addEventListener('animationstart', (e) => {
+        switch (e.animationName) {
+          case defaultStyles.onAutoFillStart:
+            return this.onAutoFillStart()
 
-        case defaultStyles.onAutoFillCancel:
-          return this.onAutoFillCancel()
-      }
-    })
+          case defaultStyles.onAutoFillCancel:
+            return this.onAutoFillCancel()
+        }
+      })
+    }
   }
 
   componentDidUpdate () {
-    if (this.props.focus && getActiveElement(document) !== this.refs.input) {
-      this.refs.input.focus()
+    const input = this.rootDOMElement.querySelector('input')
+
+    if (input && this.props.focus && getActiveElement(document) !== input) {
+      input.focus()
     }
   }
 
@@ -138,7 +143,7 @@ class Field extends Component {
         'non-floating-label': pinCode || nonFloatingLabel,
         'pin-code': pinCode,
         square,
-        'is-focused': this.props.focus
+        'is-focused': focus
       },
       fieldStates.getClassName(this.props),
       stacking.size.getClassName(this.props),
@@ -208,7 +213,8 @@ class Field extends Component {
         onClick={onClick}
         style={dynamicStyles}
         onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}>
+        onMouseLeave={onMouseLeave}
+        ref={rootDOMElement => (this.rootDOMElement = rootDOMElement)}>
         {
           inlinedIcon.renderInlinedIcon(this.props, {
             icon: classNames(classes.iconIcon),

--- a/Field/index.jsx
+++ b/Field/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
@@ -34,85 +34,26 @@ const classes = {
 
 export const icons = inlinedIcon.INLINED_ICONS
 
-const Field = React.createClass({
-  displayName: 'Field',
+class Field extends Component {
+  constructor () {
+    super()
 
-  getDefaultProps () {
-    return {
-      big: false,
-      centered: false,
-      loading: false,
-      nonFloatingLabel: false,
-      onChange: function () {},
-      onFieldLinkClick: function () {},
-      responsive: true,
-      fieldLink: '',
-      fieldTooltip: '',
-      pinCode: false,
-      mouseflowExclude: false,
-      ...inlinedIcon.defaultProps,
-      ...fieldStates.defaultProps,
-      ...stacking.position.defaultProps,
-      ...handleKeyDown.defaultProps,
-      ...stacking.size.defaultProps
-    }
-  },
-
-  propTypes: {
-    arrow: PropTypes.string,
-    big: PropTypes.bool,
-    centered: PropTypes.bool,
-    customize: PropTypes.shape({
-      borderColor: PropTypes.string.isRequired,
-      borderColorSelected: PropTypes.string.isRequired,
-      borderRadius: PropTypes.string.isRequired,
-      labelColor: PropTypes.string.isRequired,
-      inputColor: PropTypes.string.isRequired
-    }),
-    fieldLink: PropTypes.string,
-    fieldTooltip: PropTypes.string,
-    focus: PropTypes.bool,
-    hidden: PropTypes.bool,
-    id: PropTypes.string,
-    input: PropTypes.func,
-    loading: PropTypes.bool,
-    label: PropTypes.string.isRequired,
-    onBlur: PropTypes.func,
-    onChange: PropTypes.func,
-    onClick: PropTypes.func,
-    onFocus: PropTypes.func,
-    onFieldLinkClick: PropTypes.func,
-    nonFloatingLabel: PropTypes.bool,
-    pattern: PropTypes.string,
-    pinCode: PropTypes.bool,
-    mouseflowExclude: PropTypes.bool,
-    responsive: PropTypes.bool,
-    value: PropTypes.string,
-    styles: PropTypes.object,
-    ...inlinedIcon.propTypes,
-    ...fieldStates.propTypes,
-    ...handleKeyDown.propTypes,
-    ...stacking.position.propTypes,
-    ...stacking.size.propTypes
-  },
-
-  getInitialState () {
-    return {
+    this.state = {
       hover: false
     }
-  },
+  }
 
   onAutoFillStart () {
     this.setState({
       autoFill: true
     })
-  },
+  }
 
   onAutoFillCancel () {
     this.setState({
       autoFill: false
     })
-  },
+  }
 
   componentDidMount () {
     if (this.props.focus && getActiveElement(document) !== this.refs.input) {
@@ -129,25 +70,25 @@ const Field = React.createClass({
           return this.onAutoFillCancel()
       }
     })
-  },
+  }
 
   componentDidUpdate () {
     if (this.props.focus && getActiveElement(document) !== this.refs.input) {
       this.refs.input.focus()
     }
-  },
+  }
 
   onMouseEnter () {
     this.setState({
       hover: true
     })
-  },
+  }
 
   onMouseLeave () {
     this.setState({
       hover: false
     })
-  },
+  }
 
   render () {
     const {
@@ -311,7 +252,64 @@ const Field = React.createClass({
       </div>
     )
   }
-})
+}
+
+Field.propTypes = {
+  arrow: PropTypes.string,
+  big: PropTypes.bool,
+  centered: PropTypes.bool,
+  customize: PropTypes.shape({
+    borderColor: PropTypes.string.isRequired,
+    borderColorSelected: PropTypes.string.isRequired,
+    borderRadius: PropTypes.string.isRequired,
+    labelColor: PropTypes.string.isRequired,
+    inputColor: PropTypes.string.isRequired
+  }),
+  fieldLink: PropTypes.string,
+  fieldTooltip: PropTypes.string,
+  focus: PropTypes.bool,
+  hidden: PropTypes.bool,
+  id: PropTypes.string,
+  input: PropTypes.func,
+  loading: PropTypes.bool,
+  label: PropTypes.string.isRequired,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onClick: PropTypes.func,
+  onFocus: PropTypes.func,
+  onFieldLinkClick: PropTypes.func,
+  nonFloatingLabel: PropTypes.bool,
+  pattern: PropTypes.string,
+  pinCode: PropTypes.bool,
+  mouseflowExclude: PropTypes.bool,
+  responsive: PropTypes.bool,
+  value: PropTypes.string,
+  styles: PropTypes.object,
+  ...inlinedIcon.propTypes,
+  ...fieldStates.propTypes,
+  ...handleKeyDown.propTypes,
+  ...stacking.position.propTypes,
+  ...stacking.size.propTypes
+}
+
+Field.defaultProps = {
+  big: false,
+  centered: false,
+  loading: false,
+  nonFloatingLabel: false,
+  onChange: function () {},
+  onFieldLinkClick: function () {},
+  responsive: true,
+  fieldLink: '',
+  fieldTooltip: '',
+  pinCode: false,
+  mouseflowExclude: false,
+  ...inlinedIcon.defaultProps,
+  ...fieldStates.defaultProps,
+  ...stacking.position.defaultProps,
+  ...handleKeyDown.defaultProps,
+  ...stacking.size.defaultProps
+}
 
 export default compose(
   uncontrolled({

--- a/Field/index.jsx
+++ b/Field/index.jsx
@@ -16,7 +16,8 @@ import {
   overridable,
   themeable,
   uncontrolled,
-  uniqueName
+  uniqueName,
+  withHoverProps
 } from '@klarna/higher-order-components'
 
 const baseClass = 'field'
@@ -78,18 +79,6 @@ class Field extends Component {
     }
   }
 
-  onMouseEnter () {
-    this.setState({
-      hover: true
-    })
-  }
-
-  onMouseLeave () {
-    this.setState({
-      hover: false
-    })
-  }
-
   render () {
     const {
       arrow,
@@ -108,6 +97,7 @@ class Field extends Component {
       fieldTooltip,
       focus,
       hidden,
+      hovered,
       label,
       left, // eslint-disable-line no-unused-vars
       loading,
@@ -118,6 +108,8 @@ class Field extends Component {
       onClick,
       onEnter, // eslint-disable-line no-unused-vars
       onFocus,
+      onMouseEnter,
+      onMouseLeave,
       onTab, // eslint-disable-line no-unused-vars
       onFieldLinkClick,
       pinCode,
@@ -160,7 +152,7 @@ class Field extends Component {
     const dynamicStyles = customize
       ? {
         ...(hasNonDefaultState ? {} : {
-          borderColor: this.state.hover || focus
+          borderColor: hovered || focus
             ? customize.borderColorSelected
             : customize.borderColor,
           boxShadow: focus && `0 0 4px ${customize.borderColorSelected}`
@@ -215,8 +207,8 @@ class Field extends Component {
         id={id}
         onClick={onClick}
         style={dynamicStyles}
-        onMouseEnter={this.onMouseEnter}
-        onMouseLeave={this.onMouseLeave}>
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}>
         {
           inlinedIcon.renderInlinedIcon(this.props, {
             icon: classNames(classes.iconIcon),
@@ -312,6 +304,9 @@ Field.defaultProps = {
 }
 
 export default compose(
+  withHoverProps({
+    hovered: true
+  }),
   uncontrolled({
     prop: 'focus',
     defaultProp: 'autoFocus',

--- a/Input/example.jsx
+++ b/Input/example.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Input, { icons } from '../Input'
 import Fieldset from '../Fieldset'
 import { LIVE, LIVE_WIDE, MANUAL } from '../Showroom/variationTypes'
-import ReactMaskedInput from 'react-maskedinput'
+import ReactTextMask from 'react-text-mask'
 
 export default {
   title: 'Input',
@@ -92,21 +92,31 @@ export default {
     {
       title: 'Override',
       require: `import Input from '@klarna/ui/Input'
-import ReactMaskedInput from 'react-maskedinput'`,
+import ReactTextMask from 'react-text-mask'`,
       type: MANUAL,
 
       examples: {
         'Masked credit card input': {
           live: <Input
             label='Credit card number'
-            Input={ReactMaskedInput}
-            mask='1111 1111 1111 1111'
+            Input={ReactTextMask}
+            mask={[
+              /\d/, /\d/, /\d/, /\d/, ' ',
+              /\d/, /\d/, /\d/, /\d/, ' ',
+              /\d/, /\d/, /\d/, /\d/, ' ',
+              /\d/, /\d/, /\d/, /\d/
+            ]}
             placeholder=' '
           />,
           code: `<Input
   label='Credit card number'
-  Input={ReactMaskedInput}
-  mask='1111 1111 1111 1111'
+  Input={ReactTextMask}
+  mask={[
+    /\d/, /\d/, /\d/, /\d/, ' ',
+    /\d/, /\d/, /\d/, /\d/, ' ',
+    /\d/, /\d/, /\d/, /\d/, ' ',
+    /\d/, /\d/, /\d/, /\d/
+  ]}
   placeholder=' '
 />`
         }

--- a/Input/index.jsx
+++ b/Input/index.jsx
@@ -49,25 +49,30 @@ class Input extends Component {
   }
 
   componentDidMount () {
-    if (this.props.focus && getActiveElement(document) !== this.refs.input) {
-      this.refs.input.focus()
+    const input = this.rootDOMElement.querySelector('input')
+
+    if (input && this.props.focus && getActiveElement(document) !== input) {
+      input.focus()
     }
 
-    this.refs.input.addEventListener &&
-    this.refs.input.addEventListener('animationstart', (e) => {
-      switch (e.animationName) {
-        case defaultStyles.onAutoFillStart:
-          return this.onAutoFillStart()
+    if (input && input.addEventListener) {
+      input.addEventListener('animationstart', (e) => {
+        switch (e.animationName) {
+          case defaultStyles.onAutoFillStart:
+            return this.onAutoFillStart()
 
-        case defaultStyles.onAutoFillCancel:
-          return this.onAutoFillCancel()
-      }
-    })
+          case defaultStyles.onAutoFillCancel:
+            return this.onAutoFillCancel()
+        }
+      })
+    }
   }
 
   componentDidUpdate () {
-    if (this.props.focus && getActiveElement(document) !== this.refs.input) {
-      this.refs.input.focus()
+    const input = this.rootDOMElement.querySelector('input')
+
+    if (input && this.props.focus && getActiveElement(document) !== input) {
+      input.focus()
     }
   }
 
@@ -149,7 +154,8 @@ class Input extends Component {
       <div
         className={cls}
         id={id}
-        onClick={onClick}>
+        onClick={onClick}
+        ref={rootDOMElement => (this.rootDOMElement = rootDOMElement)}>
         {
           inlinedIcon.renderInlinedIcon(this.props, {
             icon: classNames(classes.iconIcon),

--- a/Input/index.jsx
+++ b/Input/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
@@ -27,65 +27,26 @@ const classes = {
 
 export const icons = inlinedIcon.INLINED_ICONS
 
-const Input = React.createClass({
-  displayName: 'Input',
+class Input extends Component {
+  constructor () {
+    super()
 
-  getDefaultProps () {
-    return {
-      big: false,
-      centered: false,
-      giant: false,
-      loading: false,
-      mouseflowExclude: false,
-      onChange: function () {},
-      ...inlinedIcon.defaultProps,
-      ...fieldStates.defaultProps,
-      ...stacking.position.defaultProps,
-      ...handleKeyDown.defaultProps,
-      ...stacking.size.defaultProps
-    }
-  },
-
-  propTypes: {
-    big: PropTypes.bool,
-    centered: PropTypes.bool,
-    focus: PropTypes.bool,
-    giant: PropTypes.bool,
-    id: PropTypes.string,
-    input: PropTypes.func,
-    loading: PropTypes.bool,
-    label: PropTypes.string.isRequired,
-    mouseflowExclude: PropTypes.bool,
-    onBlur: PropTypes.func,
-    onChange: PropTypes.func,
-    onClick: PropTypes.func,
-    onFocus: PropTypes.func,
-    value: PropTypes.string,
-    styles: PropTypes.object,
-    ...inlinedIcon.propTypes,
-    ...fieldStates.propTypes,
-    ...handleKeyDown.propTypes,
-    ...stacking.position.propTypes,
-    ...stacking.size.propTypes
-  },
-
-  getInitialState () {
-    return {
+    this.state = {
       autoFill: false
     }
-  },
+  }
 
   onAutoFillStart () {
     this.setState({
       autoFill: true
     })
-  },
+  }
 
   onAutoFillCancel () {
     this.setState({
       autoFill: false
     })
-  },
+  }
 
   componentDidMount () {
     if (this.props.focus && getActiveElement(document) !== this.refs.input) {
@@ -102,13 +63,13 @@ const Input = React.createClass({
           return this.onAutoFillCancel()
       }
     })
-  },
+  }
 
   componentDidUpdate () {
     if (this.props.focus && getActiveElement(document) !== this.refs.input) {
       this.refs.input.focus()
     }
-  },
+  }
 
   render () {
     const {
@@ -211,7 +172,44 @@ const Input = React.createClass({
       </div>
     )
   }
-})
+}
+
+Input.defaultProps = {
+  big: false,
+  centered: false,
+  giant: false,
+  loading: false,
+  mouseflowExclude: false,
+  onChange: function () {},
+  ...inlinedIcon.defaultProps,
+  ...fieldStates.defaultProps,
+  ...stacking.position.defaultProps,
+  ...handleKeyDown.defaultProps,
+  ...stacking.size.defaultProps
+}
+
+Input.propTypes = {
+  big: PropTypes.bool,
+  centered: PropTypes.bool,
+  focus: PropTypes.bool,
+  giant: PropTypes.bool,
+  id: PropTypes.string,
+  input: PropTypes.func,
+  loading: PropTypes.bool,
+  label: PropTypes.string.isRequired,
+  mouseflowExclude: PropTypes.bool,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onClick: PropTypes.func,
+  onFocus: PropTypes.func,
+  value: PropTypes.string,
+  styles: PropTypes.object,
+  ...inlinedIcon.propTypes,
+  ...fieldStates.propTypes,
+  ...handleKeyDown.propTypes,
+  ...stacking.position.propTypes,
+  ...stacking.size.propTypes
+}
 
 export default compose(
   uncontrolled({

--- a/Menu/Segmented/index.jsx
+++ b/Menu/Segmented/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
@@ -17,27 +17,7 @@ const classes = {
 
 export const tabDisplays = ['fluid', 'static']
 
-const Segmented = React.createClass({
-  displayName: 'Segmented',
-
-  propTypes: {
-    children: childrenPropType,
-    className: PropTypes.string,
-    id: PropTypes.string,
-    name: PropTypes.string.isRequired,
-    onBlur: PropTypes.func,
-    onChange: PropTypes.func,
-    onFocus: PropTypes.func,
-    options: PropTypes.arrayOf(PropTypes.shape({
-      label: PropTypes.node.isRequired,
-      key: PropTypes.string.isRequired
-    })).isRequired,
-    selectable: PropTypes.bool,
-    tabDisplay: PropTypes.oneOf(tabDisplays),
-    value: PropTypes.string,
-    white: PropTypes.bool
-  },
-
+class Segmented extends Component {
   componentDidMount () {
     if (
       this.props.focus &&
@@ -45,7 +25,7 @@ const Segmented = React.createClass({
     ) {
       this.refs[this.props.focus].focus()
     }
-  },
+  }
 
   componentDidUpdate () {
     if (
@@ -54,14 +34,7 @@ const Segmented = React.createClass({
     ) {
       this.refs[this.props.focus].focus()
     }
-  },
-
-  getDefaultProps () {
-    return {
-      selectable: true,
-      tabDisplay: 'fluid'
-    }
-  },
+  }
 
   render () {
     const {
@@ -128,7 +101,30 @@ const Segmented = React.createClass({
       </div>
     )
   }
-})
+}
+
+Segmented.propTypes = {
+  children: childrenPropType,
+  className: PropTypes.string,
+  id: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  options: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.node.isRequired,
+    key: PropTypes.string.isRequired
+  })).isRequired,
+  selectable: PropTypes.bool,
+  tabDisplay: PropTypes.oneOf(tabDisplays),
+  value: PropTypes.string,
+  white: PropTypes.bool
+}
+
+Segmented.defaultProps = {
+  selectable: true,
+  tabDisplay: 'fluid'
+}
 
 export default compose(
   uncontrolled({

--- a/MouseflowExclude/index.jsx
+++ b/MouseflowExclude/index.jsx
@@ -1,12 +1,10 @@
-import React from 'react'
+import React, {Component} from 'react'
 
 const NODE_COMMENT = 8
 const COMMENT_START = 'MouseflowExcludeStart'
 const COMMENT_END = 'MouseflowExcludeEnd'
 
-const MouseflowExclude = React.createClass({
-  displayName: 'MouseflowExclude',
-
+class MouseflowExclude extends Component {
   render () {
     return (
       <span ref={(span) => {
@@ -27,7 +25,7 @@ const MouseflowExclude = React.createClass({
       </span>
     )
   }
-})
+}
 
 export const exclude = (Component) => (props) => (
   <MouseflowExclude>

--- a/Selector/Direct/index.jsx
+++ b/Selector/Direct/index.jsx
@@ -14,78 +14,76 @@ const classes = {
   description: `${baseClass}__description`
 }
 
-export default React.createClass({
-  displayName: 'Selector.Direct',
+function Direct ({
+  className,
+  data,
+  id,
+  onSelect,
+  styles,
+  ...remainingProps
+}) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+  const ids = id
+    ? {
+      description: (key) => `${id}__${key}__description`,
+      icon: (key) => `${id}__${key}__icon`,
+      label: (key) => `${id}__${key}__label`,
+      option: (key) => `${id}__${key}__option`
+    } : {
+      description: () => {},
+      icon: () => {},
+      label: () => {},
+      option: () => {}
+    }
 
-  propTypes: {
-    className: PropTypes.string,
-    data: PropTypes.array.isRequired,
-    id: PropTypes.string,
-    onSelect: PropTypes.func,
-    styles: PropTypes.object
-  },
+  return (
+    <div
+      className={classNames(baseClass, 'title', className)}
+      id={id}
+      {...remainingProps}>
+      {data.map(({ key, label, description }) => [
+        <a
+          href={`#${key}`}
+          id={ids.option(key)}
+          onClick={(e) => {
+            e.preventDefault()
+            onSelect && onSelect(key)
+          }}
+          className={classNames(classes.item)}
+          key={key}>
+          <div
+            className={classNames(classes.label)}
+            id={ids.label(key)}>
+            {label}
+          </div>
+          {
+            description && (
+              <div
+                className={classNames(classes.description)}
+                id={ids.description(key)}>
+                {description}
+              </div>
+            )
+          }
+          <Right
+            className={classNames(classes.icon)}
+            id={ids.icon(key)}
+            color='black'
+          />
+        </a>
+      ])}
+    </div>
+  )
+}
 
-  render () {
-    const {
-      className,
-      data,
-      id,
-      onSelect,
-      styles,
-      ...remainingProps
-    } = this.props
+Direct.propTypes = {
+  className: PropTypes.string,
+  data: PropTypes.array.isRequired,
+  id: PropTypes.string,
+  onSelect: PropTypes.func,
+  styles: PropTypes.object
+}
 
-    const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
-    const ids = id
-      ? {
-        description: (key) => `${id}__${key}__description`,
-        icon: (key) => `${id}__${key}__icon`,
-        label: (key) => `${id}__${key}__label`,
-        option: (key) => `${id}__${key}__option`
-      } : {
-        description: () => {},
-        icon: () => {},
-        label: () => {},
-        option: () => {}
-      }
+Direct.displayName = 'Selector.Direct'
 
-    return (
-      <div
-        className={classNames(baseClass, 'title', className)}
-        id={id}
-        {...remainingProps}>
-        {data.map(({ key, label, description }) => [
-          <a
-            href={`#${key}`}
-            id={ids.option(key)}
-            onClick={(e) => {
-              e.preventDefault()
-              onSelect && onSelect(key)
-            }}
-            className={classNames(classes.item)}
-            key={key}>
-            <div
-              className={classNames(classes.label)}
-              id={ids.label(key)}>
-              {label}
-            </div>
-            {
-              description && (
-                <div
-                  className={classNames(classes.description)}
-                  id={ids.description(key)}>
-                  {description}
-                </div>
-              )
-            }
-            <Right
-              className={classNames(classes.icon)}
-              id={ids.icon(key)}
-              color='black'
-            />
-          </a>
-        ])}
-      </div>
-    )
-  }
-})
+export default Direct

--- a/Selector/Input/index.jsx
+++ b/Selector/Input/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import classNamesBind from 'classnames/bind'
 import {themeable, overridable} from '@klarna/higher-order-components'
@@ -27,59 +27,22 @@ const classes = {
 
 export const icons = inlinedIcon.INLINED_ICONS
 
-const SelectorInput = React.createClass({
-  displayName: 'SelectorInput',
+class SelectorInput extends Component {
+  constructor () {
+    super()
 
-  getDefaultProps () {
-    return {
-      big: false,
-      centered: false,
-      giant: false,
-      loading: false,
-      mouseflowExclude: false,
-      ...inlinedIcon.defaultProps,
-      ...fieldStates.defaultProps,
-      ...stacking.position.defaultProps,
-      ...stacking.size.defaultProps
+    this.state = {
+      hover: false
     }
-  },
-
-  getInitialState () {
-    return { hover: false }
-  },
-
-  propTypes: {
-    big: PropTypes.bool,
-    centered: PropTypes.bool,
-    customize: PropTypes.shape({
-      borderColor: PropTypes.string.isRequired,
-      borderColorSelected: PropTypes.string.isRequired,
-      labelColor: PropTypes.string.isRequired,
-      inputColor: PropTypes.string.isRequired
-    }),
-    giant: PropTypes.bool,
-    id: PropTypes.string,
-    input: PropTypes.func,
-    link: PropTypes.string,
-    loading: PropTypes.bool,
-    label: PropTypes.string.isRequired,
-    mouseflowExclude: PropTypes.bool,
-    onClick: PropTypes.func,
-    value: PropTypes.string,
-    styles: PropTypes.object,
-    ...inlinedIcon.propTypes,
-    ...fieldStates.propTypes,
-    ...stacking.position.propTypes,
-    ...stacking.size.propTypes
-  },
+  }
 
   onMouseEnter () {
     this.setState({ hover: true })
-  },
+  }
 
   onMouseLeave () {
     this.setState({ hover: false })
-  },
+  }
 
   render () {
     const {
@@ -211,7 +174,46 @@ const SelectorInput = React.createClass({
       </div>
     )
   }
-})
+}
+
+SelectorInput.displayName = 'Selector.Input'
+
+SelectorInput.defaultProps = {
+  big: false,
+  centered: false,
+  giant: false,
+  loading: false,
+  mouseflowExclude: false,
+  ...inlinedIcon.defaultProps,
+  ...fieldStates.defaultProps,
+  ...stacking.position.defaultProps,
+  ...stacking.size.defaultProps
+}
+
+SelectorInput.propTypes = {
+  big: PropTypes.bool,
+  centered: PropTypes.bool,
+  customize: PropTypes.shape({
+    borderColor: PropTypes.string.isRequired,
+    borderColorSelected: PropTypes.string.isRequired,
+    labelColor: PropTypes.string.isRequired,
+    inputColor: PropTypes.string.isRequired
+  }),
+  giant: PropTypes.bool,
+  id: PropTypes.string,
+  input: PropTypes.func,
+  link: PropTypes.string,
+  loading: PropTypes.bool,
+  label: PropTypes.string.isRequired,
+  mouseflowExclude: PropTypes.bool,
+  onClick: PropTypes.func,
+  value: PropTypes.string,
+  styles: PropTypes.object,
+  ...inlinedIcon.propTypes,
+  ...fieldStates.propTypes,
+  ...stacking.position.propTypes,
+  ...stacking.size.propTypes
+}
 
 export default compose(
   themeable((customizations, {customize}) => ({

--- a/Selector/Options/index.jsx
+++ b/Selector/Options/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import classNamesBind from 'classnames/bind'
 import compose from 'ramda/src/compose'
@@ -22,35 +22,15 @@ const classes = {
   label: `${baseClass}__label`
 }
 
-const Options = React.createClass({
-  displayName: 'Selector.Options',
+class SelectorOptions extends Component {
+  constructor () {
+    super()
 
-  propTypes: {
-    className: PropTypes.string,
-    customize: PropTypes.shape({
-      borderColor: PropTypes.string.isRequired,
-      bulletColor: PropTypes.string.isRequired,
-      labelColor: PropTypes.string.isRequired,
-      labelColorSelected: PropTypes.string.isRequired
-    }),
-    data: PropTypes.array.isRequired,
-    focus: PropTypes.any,
-    id: PropTypes.string,
-    name: PropTypes.string,
-    onBlur: PropTypes.func,
-    onChange: PropTypes.func,
-    onFocus: PropTypes.func,
-    styles: PropTypes.object,
-    // Allows any type to be a key, as long as it is comparable
-    value: PropTypes.any
-  },
-
-  getInitialState () {
-    return {
+    this.state = {
       hover: undefined,
       focus: undefined
     }
-  },
+  }
 
   componentDidMount () {
     if (
@@ -59,7 +39,7 @@ const Options = React.createClass({
     ) {
       this.refs[this.props.focus].focus()
     }
-  },
+  }
 
   componentDidUpdate () {
     if (
@@ -68,7 +48,15 @@ const Options = React.createClass({
     ) {
       this.refs[this.props.focus].focus()
     }
-  },
+  }
+
+  onOptionMouseEnter (key) {
+    this.setState({ hover: key })
+  }
+
+  onOptionMouseLeave (key) {
+    this.setState({ hover: undefined })
+  }
 
   render () {
     const {
@@ -155,16 +143,30 @@ const Options = React.createClass({
         })}
       </div>
     )
-  },
-
-  onOptionMouseEnter (key) {
-    this.setState({ hover: key })
-  },
-
-  onOptionMouseLeave (key) {
-    this.setState({ hover: undefined })
   }
-})
+}
+
+SelectorOptions.displayName = 'Selector.Options'
+
+SelectorOptions.propTypes = {
+  className: PropTypes.string,
+  customize: PropTypes.shape({
+    borderColor: PropTypes.string.isRequired,
+    bulletColor: PropTypes.string.isRequired,
+    labelColor: PropTypes.string.isRequired,
+    labelColorSelected: PropTypes.string.isRequired
+  }),
+  data: PropTypes.array.isRequired,
+  focus: PropTypes.any,
+  id: PropTypes.string,
+  name: PropTypes.string,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  styles: PropTypes.object,
+  // Allows any type to be a key, as long as it is comparable
+  value: PropTypes.any
+}
 
 export default compose(
   uncontrolled({
@@ -193,4 +195,4 @@ export default compose(
     }
   })),
   overridable(defaultStyles)
-)(Options)
+)(SelectorOptions)

--- a/Showroom/examples/compositions/UniqueIds.jsx
+++ b/Showroom/examples/compositions/UniqueIds.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {Component} from 'react'
 import * as Alert from '../../../Alert'
 import Amount from '../../../Amount'
 import * as Block from '../../../Block'
@@ -31,14 +31,14 @@ import TextLabel from '../../../TextLabel'
 import Tooltip from '../../../Tooltip'
 import {LIVE, MANUAL} from '../../variationTypes'
 
-const Example = React.createClass({
-  displayName: 'DialogExample',
+class Example extends Component {
+  constructor () {
+    super()
 
-  getInitialState () {
-    return {
+    this.state = {
       open: false
     }
-  },
+  }
 
   render () {
     const close = () => this.setState({ open: false })
@@ -80,7 +80,7 @@ const Example = React.createClass({
       </div>
     )
   }
-})
+}
 
 export default {
   title: 'UniqueIds',

--- a/Showroom/index.jsx
+++ b/Showroom/index.jsx
@@ -1,27 +1,31 @@
-import React from 'react'
+import React, {Component} from 'react'
 import * as examples from './examples'
 import Main from './Main'
 import states from './states'
 
-export default React.createClass({
-  getInitialState () {
-    return states()
-  },
+export default class Showroom extends Component {
+  constructor () {
+    super()
+
+    this.state = {
+      store: states()
+    }
+  }
 
   componentDidMount () {
-    states.map(this.replaceState.bind(this))
-  },
+    states.map(state => this.setState({store: state}))
+  }
 
   shouldComponentUpdate (nextProps, nextState) {
-    return nextState !== this.state
-  },
+    return nextState.store !== this.state.store
+  }
 
   render () {
     return (
       <Main
         examples={examples}
-        {...this.state}
+        {...this.state.store}
       />
     )
   }
-})
+}

--- a/Strong/index.jsx
+++ b/Strong/index.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import classNamesBind from 'classnames/bind'
 import compose from 'ramda/src/compose'
 import {overridable} from '@klarna/higher-order-components'

--- a/Switch/Checkbox/index.jsx
+++ b/Switch/Checkbox/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
@@ -29,58 +29,26 @@ const release = (component) => () => component.setState({ pressed: false })
 
 export const alignments = ['left', 'right']
 
-const Checkbox = React.createClass({
-  displayName: 'Switch.Checkbox',
+class Checkbox extends Component {
+  constructor () {
+    super()
 
-  getDefaultProps () {
-    return {
-      error: false,
-      disabled: false,
-      align: 'left',
-      legal: false,
-      value: false
+    this.state = {
+      pressed: false
     }
-  },
-
-  propTypes: {
-    align: PropTypes.oneOf(alignments),
-    children: childrenPropType,
-    className: PropTypes.string,
-    customize: PropTypes.shape({
-      backgroundColor: PropTypes.string.isRequired,
-      borderColorSelected: PropTypes.string.isRequired,
-      bulletColor: PropTypes.string.isRequired,
-      textColor: PropTypes.string.isRequired
-    }),
-    disabled: PropTypes.bool,
-    partial: PropTypes.bool,
-    error: PropTypes.bool,
-    focus: PropTypes.bool,
-    id: PropTypes.string,
-    legal: PropTypes.bool,
-    name: PropTypes.string,
-    onBlur: PropTypes.func,
-    onChange: PropTypes.func,
-    onFocus: PropTypes.func,
-    styles: PropTypes.object,
-    value: PropTypes.bool
-  },
+  }
 
   componentDidMount () {
     if (this.props.focus && getActiveElement(document) !== this.refs.input) {
       this.refs.input.focus()
     }
-  },
+  }
 
   componentDidUpdate () {
     if (this.props.focus && getActiveElement(document) !== this.refs.input) {
       this.refs.input.focus()
     }
-  },
-
-  getInitialState () {
-    return {pressed: false}
-  },
+  }
 
   render () {
     const {
@@ -190,7 +158,41 @@ const Checkbox = React.createClass({
       </label>
     </div>)
   }
-})
+}
+
+Checkbox.displayName = 'Switch.Checkbox'
+
+Checkbox.defaultProps = {
+  error: false,
+  disabled: false,
+  align: 'left',
+  legal: false,
+  value: false
+}
+
+Checkbox.propTypes = {
+  align: PropTypes.oneOf(alignments),
+  children: childrenPropType,
+  className: PropTypes.string,
+  customize: PropTypes.shape({
+    backgroundColor: PropTypes.string.isRequired,
+    borderColorSelected: PropTypes.string.isRequired,
+    bulletColor: PropTypes.string.isRequired,
+    textColor: PropTypes.string.isRequired
+  }),
+  disabled: PropTypes.bool,
+  partial: PropTypes.bool,
+  error: PropTypes.bool,
+  focus: PropTypes.bool,
+  id: PropTypes.string,
+  legal: PropTypes.bool,
+  name: PropTypes.string,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  styles: PropTypes.object,
+  value: PropTypes.bool
+}
 
 export default compose(
   uncontrolled({

--- a/Switch/Toggle/index.jsx
+++ b/Switch/Toggle/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from './styles.scss'
@@ -31,6 +31,7 @@ const pressTouch = (component) => (e) => {
     touchStartPositionX: e.changedTouches[0].pageX
   })
 }
+
 const releaseTouch = (component) => (e) => {
   const { touchStartPositionX } = component.state
   const touchPositionX = e.changedTouches[0].pageX
@@ -54,6 +55,7 @@ const releaseTouch = (component) => (e) => {
     bulletPosition: undefined
   })
 }
+
 const dragTouch = (component) => (e) => {
   const { position, pseudoValue } = getRelativeOffset(component, e.changedTouches[0].pageX)
   component.setState({
@@ -106,58 +108,26 @@ const getRelativeOffset = (component, touchPositionX) => {
 
 export const alignments = ['left', 'right']
 
-const Toggle = React.createClass({
-  displayName: 'Switch.Toggle',
+class Toggle extends Component {
+  constructor () {
+    super()
 
-  getDefaultProps () {
-    return {
-      error: false,
-      disabled: false,
-      align: 'left',
-      legal: false,
-      value: false
+    this.state = {
+      pressed: false
     }
-  },
-
-  propTypes: {
-    children: childrenPropType,
-    className: PropTypes.string,
-    customize: PropTypes.shape({
-      backgroundColor: PropTypes.string.isRequired,
-      bulletColor: PropTypes.string.isRequired,
-      textColor: PropTypes.string.isRequired
-    }),
-    disabled: PropTypes.bool,
-    error: PropTypes.bool,
-    focus: PropTypes.bool,
-    id: PropTypes.string,
-    legal: PropTypes.bool,
-    name: PropTypes.string.isRequired,
-    align: PropTypes.oneOf(alignments),
-    onBlur: PropTypes.func,
-    onChange: PropTypes.func,
-    onFocus: PropTypes.func,
-    styles: PropTypes.object,
-    value: PropTypes.bool
-  },
+  }
 
   componentDidMount () {
     if (this.props.focus && getActiveElement(document) !== this.refs.input) {
       this.refs.input.focus()
     }
-  },
+  }
 
   componentDidUpdate () {
     if (this.props.focus && getActiveElement(document) !== this.refs.input) {
       this.refs.input.focus()
     }
-  },
-
-  getInitialState () {
-    return {
-      pressed: false
-    }
-  },
+  }
 
   render () {
     const {
@@ -255,7 +225,39 @@ const Toggle = React.createClass({
       </label>
     </div>)
   }
-})
+}
+
+Toggle.displayName = 'Switch.Toggle'
+
+Toggle.defaultProps = {
+  error: false,
+  disabled: false,
+  align: 'left',
+  legal: false,
+  value: false
+}
+
+Toggle.propTypes = {
+  children: childrenPropType,
+  className: PropTypes.string,
+  customize: PropTypes.shape({
+    backgroundColor: PropTypes.string.isRequired,
+    bulletColor: PropTypes.string.isRequired,
+    textColor: PropTypes.string.isRequired
+  }),
+  disabled: PropTypes.bool,
+  error: PropTypes.bool,
+  focus: PropTypes.bool,
+  id: PropTypes.string,
+  legal: PropTypes.bool,
+  name: PropTypes.string.isRequired,
+  align: PropTypes.oneOf(alignments),
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  styles: PropTypes.object,
+  value: PropTypes.bool
+}
 
 export default compose(
   uncontrolled({

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "postcss-loader": "^1.3.3",
     "prop-types": "^15.5.9",
     "ramda": "^0.21.0",
-    "react": "15.4.0",
+    "react": "15.5.4",
     "react-addons-test-utils": "^15.4.0",
     "react-dom": "15.4.0",
     "react-element-to-jsx-string": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "html2react": "^1.0.2",
     "prop-types": "^15.5.9",
     "ramda": "^0.21.0",
-    "react": "^0.14.0 || ^15.0.0",
+    "react": "^0.14.9 || ^15.3.0",
     "react-motion": "^0.5.0"
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "author": "Klarna front end people",
   "dependencies": {
-    "@klarna/higher-order-components": "0.6.0",
+    "@klarna/higher-order-components": "0.8.2",
     "classnames": "2.2.5",
     "deepmerge": "^1.3.2",
     "parse-color": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react-maskedinput": "^3.3.1",
     "react-motion": "^0.4.2",
     "react-syntax-highlighter": "^2.2.0",
+    "react-text-mask": "^5.0.2",
     "recompose": "^0.22.0",
     "resolve-url-loader": "^1.2.0",
     "sass-lint": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-element-to-jsx-string": "^4.1.0",
     "react-hot-loader": "^3.0.0-beta.6",
     "react-maskedinput": "^3.3.1",
-    "react-motion": "^0.4.2",
+    "react-motion": "^0.5.0",
     "react-syntax-highlighter": "^2.2.0",
     "react-text-mask": "^5.0.2",
     "recompose": "^0.22.0",
@@ -94,7 +94,7 @@
     "prop-types": "^15.5.9",
     "ramda": "^0.21.0",
     "react": "^0.14.0 || ^15.0.0",
-    "react-motion": "^0.4.2"
+    "react-motion": "^0.5.0"
   },
   "standard": {
     "globals": [

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
   },
   "author": "Klarna front end people",
   "dependencies": {
-    "@klarna/higher-order-components": "0.8.2",
+    "@klarna/higher-order-components": "0.8.4",
     "classnames": "2.2.5",
     "deepmerge": "^1.3.2",
     "parse-color": "1.0.0",
     "react-component-queries": "^2.1.1",
-    "react-context-props": "^0.1.4",
+    "react-context-props": "^2.2.0",
     "react-sizeme": "^2.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4876,7 +4876,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.9:
+prop-types@^15.5.7, prop-types@^15.5.9:
   version "15.5.9"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.9.tgz#d478eef0e761396942f70c78e772f76e8be747c9"
   dependencies:
@@ -5091,13 +5091,14 @@ react-syntax-highlighter@^2.2.0:
     highlight.js "~9.7.0"
     lowlight "^1.2.0"
 
-react@15.4.0:
-  version "15.4.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.4.0.tgz#736c1c7c542e8088127106e1f450b010f86d172b"
+react@15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "^15.5.7"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@klarna/higher-order-components@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@klarna/higher-order-components/-/higher-order-components-0.6.0.tgz#fb4ef79cc16b91d7ee40f82b9337b23c1ac55961"
+"@klarna/higher-order-components@0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@klarna/higher-order-components/-/higher-order-components-0.8.2.tgz#afc9e530cafac6c7ad9e73216a1ae5234653d60b"
   dependencies:
     collect-fps "2.0.0"
     seed-random "^2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4876,7 +4876,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.7, prop-types@^15.5.9:
+prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.9:
   version "15.5.9"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.9.tgz#d478eef0e761396942f70c78e772f76e8be747c9"
   dependencies:
@@ -5090,6 +5090,12 @@ react-syntax-highlighter@^2.2.0:
   dependencies:
     highlight.js "~9.7.0"
     lowlight "^1.2.0"
+
+react-text-mask@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/react-text-mask/-/react-text-mask-5.0.2.tgz#09bce3f94ac244c11932082e42328cb455b73aa6"
+  dependencies:
+    prop-types "^15.5.6"
 
 react@15.5.4:
   version "15.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@klarna/higher-order-components@0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@klarna/higher-order-components/-/higher-order-components-0.8.2.tgz#afc9e530cafac6c7ad9e73216a1ae5234653d60b"
+"@klarna/higher-order-components@0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@klarna/higher-order-components/-/higher-order-components-0.8.4.tgz#028aaeac545d4b85c5814bca83e95eebedc86390"
   dependencies:
     collect-fps "2.0.0"
     seed-random "^2.2.0"
@@ -5018,9 +5018,9 @@ react-component-queries@^2.1.1:
   dependencies:
     invariant "^2.2.0"
 
-react-context-props@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/react-context-props/-/react-context-props-0.1.4.tgz#ff6811e0656dfc613bf7efe0981a6d8bbf226ffc"
+react-context-props@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-context-props/-/react-context-props-2.2.0.tgz#1f0bd558b337482c7e437a13699acf7938bca18c"
 
 react-deep-force-update@^2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4876,7 +4876,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.9:
+prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9:
   version "15.5.9"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.9.tgz#d478eef0e761396942f70c78e772f76e8be747c9"
   dependencies:
@@ -5063,11 +5063,12 @@ react-maskedinput@^3.3.1:
   dependencies:
     inputmask-core "^2.1.1"
 
-react-motion@^0.4.2:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.4.7.tgz#f77331ec7920bdb0d0cfc37eb6ffa10571bf42c7"
+react-motion@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.0.tgz#1708fc2aee552900d21c1e6bed28346863e017b6"
   dependencies:
     performance-now "^0.2.0"
+    prop-types "^15.5.8"
     raf "^3.1.0"
 
 react-proxy@^3.0.0-alpha.0:


### PR DESCRIPTION
tl;dr React 16 will deprecate `React.createClass` and `React.PropTypes` so we need to ensure that nothing we depend on will break. We still need to find out specifically what needs to be fixed. 

---

Pending updates are:

- [x] `React.createClass` is still being used throughout the library. This should be changed.
- [ ] `React.createClass` is being used by some dependencies. Those dependencies have to be identified and updated or replaced.
- [ ] `React.PropTypes` (instead of standalone `PropTypes`) is still being used by several dependencies. Also need to be identified and updated or replaced.