### PR TITLE
Make Preview themeable

### DIFF
--- a/Preview/example.jsx
+++ b/Preview/example.jsx
@@ -33,6 +33,22 @@ export default {
         <Preview.Link>
           Change address
         </Preview.Link>
+      </Preview.Main>,
+
+      'With Customizations': <Preview.Main
+        onClick={() => console.log('You clicked the address')}
+        customize={{ borderColor: 'purple', borderRadius: '10px' }}
+      >
+        <Preview.Title customize={{ textColor: 'red' }}>John Smith</Preview.Title>
+        <Preview.Content customize={{ textColor: 'green' }}>
+          1425 North Avenue Street<br />
+          San Francisco<br />
+          94100 California<br />
+          United States
+        </Preview.Content>
+        <Preview.Link customize={{ linkColor: 'brown' }}>
+          Change address
+        </Preview.Link>
       </Preview.Main>
     }
   }

--- a/Preview/index.jsx
+++ b/Preview/index.jsx
@@ -48,7 +48,11 @@ PreviewMain.propTypes = {
   className: PropTypes.string,
   children: childrenPropType,
   id: PropTypes.string,
-  styles: PropTypes.object
+  styles: PropTypes.object,
+  customize: PropTypes.shape({
+    borderColor: PropTypes.string.isRequired,
+    borderRadius: PropTypes.string.isRequired
+  })
 }
 
 export const Main = compose(
@@ -62,43 +66,87 @@ export const Main = compose(
   overridable(defaultStyles)
 )(PreviewMain)
 
-export function Content ({children, className, styles, ...props}) {
+function PreviewContent ({children, className, customize, styles, ...props}) {
   const classNames = classNamesBind.bind({...defaultStyles, ...styles})
 
+  const dynamicStyles = customize
+    ? {
+      color: customize.textColor
+    } : {}
+
   return (
-    <div className={classNames(classes.content)} {...props}>
+    <div
+      className={classNames(classes.content)}
+      style={{...dynamicStyles}}
+      {...props}
+    >
       {children}
     </div>
   )
 }
 
-Content.displayName = 'Preview.Content'
+PreviewContent.displayName = 'Preview.Content'
 
-Content.propTypes = {
+PreviewContent.propTypes = {
   className: PropTypes.string,
   children: childrenPropType,
   id: PropTypes.string,
-  styles: PropTypes.object
+  styles: PropTypes.object,
+  customize: PropTypes.shape({
+    textColor: PropTypes.string.isRequired
+  })
 }
 
-export function Title ({children, className, styles, ...props}) {
+export const Content = compose(
+  themeable((customizations, {customize}) => ({
+    customize: {
+      textColor: customizations.color_text_secondary,
+      ...customize
+    }
+  })),
+  overridable(defaultStyles)
+)(PreviewContent)
+
+function PreviewTitle ({children, className, customize, styles, ...props}) {
   const classNames = classNamesBind.bind({...defaultStyles, ...styles})
 
+  const dynamicStyles = customize
+    ? {
+      color: customize.textColor
+    } : {}
+
   return (
-    <h2 className={classNames(classes.title, className)} {...props}>
+    <h2
+      className={classNames(classes.title, className)}
+      style={{...dynamicStyles}}
+      {...props}
+    >
       {children}
     </h2>
   )
 }
 
-Title.displayName = 'Preview.Title'
+PreviewTitle.displayName = 'Preview.Title'
 
-Title.propTypes = {
+PreviewTitle.propTypes = {
   className: PropTypes.string,
   children: childrenPropType,
   id: PropTypes.string,
-  styles: PropTypes.object
+  styles: PropTypes.object,
+  customize: PropTypes.shape({
+    textColor: PropTypes.string.isRequired
+  })
 }
+
+export const Title = compose(
+  themeable((customizations, {customize}) => ({
+    customize: {
+      textColor: customizations.color_text,
+      ...customize
+    }
+  })),
+  overridable(defaultStyles)
+)(PreviewTitle)
 
 function PreviewLink ({children, className, customize, id, styles, ...props}) {
   const classNames = classNamesBind.bind({...defaultStyles, ...styles})

--- a/Preview/index.jsx
+++ b/Preview/index.jsx
@@ -5,6 +5,9 @@ import contains from '../lib/contains'
 import defaultStyles from './styles.scss'
 import childrenPropType from '../propTypes/children'
 
+import compose from 'ramda/src/compose'
+import { overridable, themeable } from '@klarna/higher-order-components'
+
 const baseClass = 'preview'
 
 const classes = {
@@ -14,7 +17,7 @@ const classes = {
   title: `${baseClass}__title`
 }
 
-export function Main ({ className, children, styles, ...props }) {
+function PreviewMain ({ className, children, customize, styles, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
   const cls = classNames(
     baseClass,
@@ -22,21 +25,42 @@ export function Main ({ className, children, styles, ...props }) {
     className
   )
 
+  const dynamicStyles = customize
+    ? {
+      borderColor: customize.borderColor,
+      borderRadius: customize.borderRadius
+    } : {}
+
   return (
-    <div className={cls} {...props}>
+    <div
+      className={cls}
+      style={{...dynamicStyles}}
+      {...props}
+    >
       {children}
     </div>
   )
 }
 
-Main.displayName = 'Preview.Main'
+PreviewMain.displayName = 'Preview.Main'
 
-Main.propTypes = {
+PreviewMain.propTypes = {
   className: PropTypes.string,
   children: childrenPropType,
   id: PropTypes.string,
   styles: PropTypes.object
 }
+
+export const Main = compose(
+  themeable((customizations, {customize}) => ({
+    customize: {
+      borderColor: customizations.color_border,
+      borderRadius: customizations.radius_border,
+      ...customize
+    }
+  })),
+  overridable(defaultStyles)
+)(PreviewMain)
 
 export function Content ({children, className, styles, ...props}) {
   const classNames = classNamesBind.bind({...defaultStyles, ...styles})
@@ -76,17 +100,23 @@ Title.propTypes = {
   styles: PropTypes.object
 }
 
-export function Link ({children, className, id, styles, ...props}) {
+function PreviewLink ({children, className, customize, id, styles, ...props}) {
   const classNames = classNamesBind.bind({...defaultStyles, ...styles})
   const ids = id
     ? {
       link: `${id}__link`
     } : {}
 
+  const dynamicStyles = customize
+    ? {
+      color: customize.linkColor
+    } : {}
+
   return (
     <div className={classNames(classes.footer)} id={id}>
       <a
         className={classNames(classes.footerLink, className)}
+        style={{...dynamicStyles}}
         id={ids.link}
         {...props}>
         {children}
@@ -95,11 +125,24 @@ export function Link ({children, className, id, styles, ...props}) {
   )
 }
 
-Link.displayName = 'Preview.Link'
+PreviewLink.displayName = 'Preview.Link'
 
-Link.propTypes = {
+PreviewLink.propTypes = {
   className: PropTypes.string,
   children: childrenPropType,
   id: PropTypes.string,
-  styles: PropTypes.object
+  styles: PropTypes.object,
+  customize: PropTypes.shape({
+    linkColor: PropTypes.string.isRequired
+  })
 }
+
+export const Link = compose(
+  themeable((customizations, {customize}) => ({
+    customize: {
+      linkColor: customizations.color_link,
+      ...customize
+    }
+  })),
+  overridable(defaultStyles)
+)(PreviewLink)

--- a/Theme/example.jsx
+++ b/Theme/example.jsx
@@ -15,6 +15,7 @@ import * as Paragraph from '../Paragraph'
 import * as Selector from '../Selector'
 import * as List from '../List'
 import * as Block from '../Block'
+import * as Preview from '../Preview'
 import { Back, Hamburger } from '../IconButton'
 import { LIVE } from '../Showroom/variationTypes'
 
@@ -207,6 +208,19 @@ import * as List from '@klarna/ui/List'`,
           <Field bottom left size='1/2' error label='Family name' />
           <Dropdown bottom right size='1/2' label='Middle name' options={options} autoFocus />
         </Fieldset>
+
+        <Preview.Main>
+          <Preview.Title>John Smith</Preview.Title>
+          <Preview.Content>
+            1425 North Avenue Street<br />
+            San Francisco<br />
+            94100 California<br />
+            United States
+          </Preview.Content>
+          <Preview.Link>
+            Change address
+          </Preview.Link>
+        </Preview.Main>
 
         <div style={{paddingBottom: '20px'}}>
           <BoxSelector


### PR DESCRIPTION
My attempt at making the components inside the Preview component themeable/customizable.

I don't have access to the styleguide because I don't have Sketch on my laptop, which means that I might or might not be off on what styles to use where.

One thing I wasn't able to figure out was how to use the dynamic border-color only when Preview.Main is hovered. Right now the border-color is set as default and hovering Main doesn't do anything. If anyone has an idea of how to get that working, please let me know. Or, maybe border-color isn't actually necessary here(?)

Also, please let me know if it's expected that I add another Preview example that contain these customization options.