### PR TITLE
"Fix" Dialog X-Icon in Narrow + Disabled Dropdown Cursor

### DIFF
--- a/Dialog/styles.scss
+++ b/Dialog/styles.scss
@@ -91,6 +91,7 @@
   position: absolute;
   right: ($grid * 4);
   top: ($grid * 4);
+  z-index: 1;
 
   &.left {
     left: ($grid * 4);

--- a/Dropdown/styles.scss
+++ b/Dropdown/styles.scss
@@ -87,6 +87,10 @@
     background-color: #fafafa;
     border-color: map-get($colors, grey-lines);
 
+    .dropdown__select {
+      cursor: default;
+    }
+
     &:hover {
       border-color: map-get($colors, grey-lines);
     }


### PR DESCRIPTION
Make dialog X-icon easier to click/touch in narrow layout and use default cursor on disabled dropdown.