### PR TITLE
Accept SingleInputPrompt when enter is pressed

### DIFF
--- a/templates/SingleInputPrompt/index.jsx
+++ b/templates/SingleInputPrompt/index.jsx
@@ -58,6 +58,7 @@ function SingleInputPrompt ({
         label={label}
         onBlur={onBlur}
         onChange={onChange}
+        onEnter={onAccept}
         onFocus={onFocus}
         value={value}
         disabled={loading}


### PR DESCRIPTION
### Summary

This PR intends to solve the bug in issue #372 , according to the intended behavior the `onAccept` method passed as a prop to `SingleInputPrompt` should be invoked when enter is pressed while the focus is in `Input` component but it's not invoked. 

First PR :tada: 

### Test Plan

The current tests are all passing. Tested this with `yarn:test` and `yarn:test-unit`. Verified this behavior successfully by running the current test examples for `SingleInputPrompt`

cc @OscarF 