### PR TITLE
fix for fastclick making labels not working properly in iOS WebViews

### DIFF
--- a/Radio/Option/styles.js
+++ b/Radio/Option/styles.js
@@ -45,7 +45,8 @@ export default {
     },
     inner: {
       display: 'table-row',
-      width: '100%'
+      width: '100%',
+      pointerEvents: 'none'
     },
     left: {
       display: 'table-cell',

--- a/Switch/Checkbox/styles.scss
+++ b/Switch/Checkbox/styles.scss
@@ -8,6 +8,12 @@
   &.is-disabled {
     opacity: .2;
   }
+
+  // This is a fix for fastclick making labels not working properly in iOS WebViews
+  // https://github.com/ftlabs/fastclick/issues/60
+  label > * {
+    pointer-events: none;
+  }
 }
 
 .switch--checkbox__input {


### PR DESCRIPTION
https://github.com/ftlabs/fastclick/issues/60

This fix is just for the checkbox. I guess I should do the same for `Radio`

Is this the right way to do it? Or should I try to use styles in JavaScript?