### PR TITLE
Revert "Merge pull request #395 from klarna/fix-for-fastclick-making-…

### DIFF
--- a/Radio/Option/styles.js
+++ b/Radio/Option/styles.js
@@ -45,8 +45,7 @@ export default {
     },
     inner: {
       display: 'table-row',
-      width: '100%',
-      pointerEvents: 'none'
+      width: '100%'
     },
     left: {
       display: 'table-cell',

--- a/Switch/Checkbox/styles.scss
+++ b/Switch/Checkbox/styles.scss
@@ -8,12 +8,6 @@
   &.is-disabled {
     opacity: .2;
   }
-
-  // This is a fix for fastclick making labels not working properly in iOS WebViews
-  // https://github.com/ftlabs/fastclick/issues/60
-  label > * {
-    pointer-events: none;
-  }
 }
 
 .switch--checkbox__input {


### PR DESCRIPTION
…labels-unresponsive"

We are abolishing fastclick, so no fixes are needed (and they did not work very well)

This reverts commit 27eef02b1f8b45537f49ef4060ae1d535baad441, reversing
changes made to 8e808ad4cdc51d78b105555af92905a6b487dcb3.