### PR TITLE
Add `acceptDisabled` to Landing template

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klarna/ui",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Klarna's UI Components",
   "repository": {
     "type": "git",

--- a/templates/chromes/Centered/index.jsx
+++ b/templates/chromes/Centered/index.jsx
@@ -31,6 +31,7 @@ export default function Centered ({
   id,
   illustration,
   loading,
+  acceptDisabled,
   onAccept,
   onCancel,
   styles,
@@ -79,6 +80,7 @@ export default function Centered ({
 
     {labels.accept && onAccept && <Button.Primary
       id={ids.accept}
+      disabled={acceptDisabled}
       brandVolume={brandVolume}
       onClick={onAccept}
       loading={loading}
@@ -116,4 +118,8 @@ export default function Centered ({
       {labels.legal}
     </Paragraph.Legal>}
   </Dialog.Content>
+}
+
+Centered.defaultProps = {
+  acceptDisabled: false
 }

--- a/templates/examples/Informative.jsx
+++ b/templates/examples/Informative.jsx
@@ -177,6 +177,36 @@ export default {
           </Wrapper>
         },
 
+        'With disabled button': {
+          inline: <Landing
+            illustration={<DemoIcon />}
+            labels={{
+              title: 'Welcome to the site',
+              summary: 'Chia williamsburg subway tile vaporware, live-edge kinfolk cardigan prism deep v retro seitan.',
+              accept: 'Continue',
+              cancel: 'Go back'
+            }}
+            acceptDisabled
+            onAccept={() => console.log('accept')}
+            onCancel={() => console.log('cancel')}
+          />,
+
+          wrapper: <Wrapper>
+            <Landing
+              illustration={<DemoIcon />}
+              labels={{
+                title: 'Welcome to the site',
+                summary: 'Chia williamsburg subway tile vaporware, live-edge kinfolk cardigan prism deep v retro seitan.',
+                accept: 'Continue',
+                cancel: 'Go back'
+              }}
+              acceptDisabled
+              onAccept={() => console.log('accept')}
+              onCancel={() => console.log('cancel')}
+            />
+          </Wrapper>
+        },
+
         'No Buttons': {
           inline: <Landing
             illustration={<DemoIcon />}


### PR DESCRIPTION
To disable Accept button in case you don't want to show an internal Loader.