### PR TITLE
Remove unnecessary top offset

### DIFF
--- a/Dropdown/styles.scss
+++ b/Dropdown/styles.scss
@@ -14,7 +14,6 @@
   margin-bottom: ($grid * -.2);
   position: relative;
   text-align: left;
-  top: ($grid * -.2);
   transition: border-color .2s ease, background-color .2s ease, box-shadow .2s ease;
 
   &:after {


### PR DESCRIPTION
The `top` styling for the Dropdown causes it to be 1px out of position. This makes it look like there's a 2px border when stacked with other Field components.

With `top: ($grid * -.2);`
<img width="599" alt="screen shot 2017-07-18 at 11 19 20 am" src="https://user-images.githubusercontent.com/2633655/28325272-5b59fb2c-6bab-11e7-9f91-7158f8b5ad4e.png">

Without `top: ($grid * -.2);`
<img width="599" alt="screen shot 2017-07-18 at 11 20 18 am" src="https://user-images.githubusercontent.com/2633655/28325271-5b572140-6bab-11e7-9cfa-df98e5190ada.png">
