### PR TITLE
Call 'withOverrideFromContext' last when composing HOCs

### DIFF
--- a/BoxSelector/Horizontal/index.jsx
+++ b/BoxSelector/Horizontal/index.jsx
@@ -242,6 +242,6 @@ export default compose(
       ...customize
     }
   })),
-  withOverrideFromContext,
-  withUniqueFormIdentifier
+  withUniqueFormIdentifier,
+  withOverrideFromContext
 )(Horizontal)

--- a/BoxSelector/Vertical/index.jsx
+++ b/BoxSelector/Vertical/index.jsx
@@ -242,6 +242,6 @@ export default compose(
       ...customize
     }
   })),
-  withOverrideFromContext,
-  withUniqueFormIdentifier
+  withUniqueFormIdentifier,
+  withOverrideFromContext
 )(Vertical)

--- a/Dropdown/index.jsx
+++ b/Dropdown/index.jsx
@@ -299,6 +299,6 @@ export default compose(
       ...customize
     }
   })),
-  withOverrideFromContext,
-  withUniqueFormIdentifier
+  withUniqueFormIdentifier,
+  withOverrideFromContext
 )(Dropdown)

--- a/Field/index.jsx
+++ b/Field/index.jsx
@@ -342,6 +342,6 @@ export default compose(
       ...customize
     }
   })),
-  withOverrideFromContext,
-  withUniqueFormIdentifier
+  withUniqueFormIdentifier,
+  withOverrideFromContext
 )(Field)

--- a/IconButton/Back/index.jsx
+++ b/IconButton/Back/index.jsx
@@ -60,6 +60,6 @@ Back.propTypes = {
 
 export default compose(
   withTheme(() => ({color: 'gray'})),
-  withOverrideFromContext,
-  withDisplayName('Back')
+  withDisplayName('Back'),
+  withOverrideFromContext
 )(Back)

--- a/IconButton/Close/index.jsx
+++ b/IconButton/Close/index.jsx
@@ -61,6 +61,6 @@ Close.propTypes = {
 
 export default compose(
   withTheme(() => ({color: 'gray'})),
-  withOverrideFromContext,
-  withDisplayName('Close')
+  withDisplayName('Close'),
+  withOverrideFromContext
 )(Close)

--- a/IconButton/Hamburger/index.jsx
+++ b/IconButton/Hamburger/index.jsx
@@ -63,6 +63,6 @@ Hamburger.propTypes = {
 
 export default compose(
   withTheme(() => ({color: 'gray'})),
-  withOverrideFromContext,
-  withDisplayName('Hamburger')
+  withDisplayName('Hamburger'),
+  withOverrideFromContext
 )(Hamburger)

--- a/IconButton/Options/index.jsx
+++ b/IconButton/Options/index.jsx
@@ -61,6 +61,6 @@ Options.propTypes = {
 
 export default compose(
   withTheme(() => ({color: 'gray'})),
-  withOverrideFromContext,
-  withDisplayName('Options')
+  withDisplayName('Options'),
+  withOverrideFromContext
 )(Options)

--- a/IconButton/Search/index.jsx
+++ b/IconButton/Search/index.jsx
@@ -60,6 +60,6 @@ Search.propTypes = {
 
 export default compose(
   withTheme(() => ({color: 'gray'})),
-  withOverrideFromContext,
-  withDisplayName('Search')
+  withDisplayName('Search'),
+  withOverrideFromContext
 )(Search)

--- a/IconButton/Select/index.jsx
+++ b/IconButton/Select/index.jsx
@@ -65,6 +65,6 @@ Select.propTypes = {
 
 export default compose(
   withTheme(() => ({color: 'gray'})),
-  withOverrideFromContext,
-  withDisplayName('Select')
+  withDisplayName('Select'),
+  withOverrideFromContext
 )(Select)

--- a/Radio/index.js
+++ b/Radio/index.js
@@ -277,6 +277,6 @@ export default compose(
       ...customize
     }
   })),
-  withOverrideFromContext,
-  withUniqueFormIdentifier
+  withUniqueFormIdentifier,
+  withOverrideFromContext
 )(Radio)

--- a/Switch/Checkbox/index.jsx
+++ b/Switch/Checkbox/index.jsx
@@ -218,6 +218,6 @@ export default compose(
       ...customize
     }
   })),
-  withOverrideFromContext,
-  withUniqueFormIdentifier
+  withUniqueFormIdentifier,
+  withOverrideFromContext
 )(Checkbox)

--- a/Switch/Toggle/index.jsx
+++ b/Switch/Toggle/index.jsx
@@ -281,6 +281,6 @@ export default compose(
       ...customize
     }
   })),
-  withOverrideFromContext,
-  withUniqueFormIdentifier
+  withUniqueFormIdentifier,
+  withOverrideFromContext
 )(Toggle)


### PR DESCRIPTION
The current implementation of `withOverrideFromContext` relies on the `displayName` of its target to find the override props for it in the React context. This approach does not work when `withOverrideFromContext` is not the first HOC to wrap the target component in the function composition order. 

This patch changes the order of the composition to make `withOverrideFromContext` be the first HOC that wraps the UI components to mitigate the issue while `withOverrideFromContext` does not get patched.

Suggestion to make `withOverrideFromContext` more reliable: Wrap it in a closure that takes a `targetName` argument and uses it to get override props from the context.