### PR TITLE
Remove margins of `ul` inside of `Checklist` component

### DIFF
--- a/Checklist/styles.scss
+++ b/Checklist/styles.scss
@@ -9,6 +9,7 @@
 
   ul {
     list-style: none;
+    margin: 0;
     padding: ($grid * 2) ($grid * 4) ($grid * 2.8);
   }
 


### PR DESCRIPTION
The margins of the `ul` were previously removed, but since the `margin` was transferred moved to the new wrapping `div`, the defaults are now being used instead.