### PR TITLE
Fix checklist margins and paddings

### DIFF
--- a/Checklist/index.jsx
+++ b/Checklist/index.jsx
@@ -11,6 +11,7 @@ import { withOverrideFromContext, withTheme } from '@klarna/higher-order-compone
 const baseClass = 'checklist'
 
 const classes = {
+  title: `${baseClass}__title`,
   item: `${baseClass}__item`,
   checkmark: `${baseClass}__checkmark`,
   footer: `${baseClass}__footer`
@@ -25,6 +26,10 @@ function ChecklistMain ({ chromeless, className, children, title, customize, sty
       borderColor: customize.borderColor
     } : {}
 
+  const allChildren = React.Children.toArray(children)
+  const items = allChildren.filter((child) => child.type === Item)
+  const footer = allChildren.filter((child) => child.type === Footer)
+
   return <div
     style={{
       ...dynamicStyles,
@@ -32,11 +37,13 @@ function ChecklistMain ({ chromeless, className, children, title, customize, sty
     }}
     className={classNames(baseClass, { chromeless }, className)}
   >
-    <ul
-      {...props}>
-      {title && <h1>{title}</h1>}
-      {children}
+    {title && <h1 className={classNames(classes.title)}>{title}</h1>}
+
+    <ul {...props}>
+      {items}
     </ul>
+
+    {footer}
   </div>
 }
 

--- a/Checklist/styles.scss
+++ b/Checklist/styles.scss
@@ -14,7 +14,6 @@
     padding: 0;
   }
 
-
   &.chromeless {
     background: transparent;
     border: 0;
@@ -25,8 +24,8 @@
   &__title {
     @include subtitle;
 
-    text-align: center;
     padding-top: ($grid * 1.2);
+    text-align: center;
   }
 
   &__item {
@@ -52,9 +51,9 @@
       @include typography(map-get($font-sizes, main-body-desktop), regular);
     }
 
-    text-align: center;
-    padding-top: ($grid * 1.4);
     padding-bottom: $grid;
+    padding-top: ($grid * 1.4);
+    text-align: center;
   }
 
   &__checkmark {

--- a/Checklist/styles.scss
+++ b/Checklist/styles.scss
@@ -6,24 +6,27 @@
   border-radius: $border-radius;
   line-height: ($grid * 4);
   margin: ($grid * -.2) 0 0 0;
+  padding: ($grid * 2) ($grid * 4) ($grid * 2.8);
 
   ul {
     list-style: none;
     margin: 0;
-    padding: ($grid * 2) ($grid * 4) ($grid * 2.8);
+    padding: 0;
   }
 
-  h1 {
-    @include subtitle;
-
-    text-align: center;
-  }
 
   &.chromeless {
     background: transparent;
     border: 0;
     margin: 0;
     padding: 0;
+  }
+
+  &__title {
+    @include subtitle;
+
+    text-align: center;
+    padding-top: ($grid * 1.2);
   }
 
   &__item {
@@ -48,7 +51,10 @@
     @include respond-to-wide {
       @include typography(map-get($font-sizes, main-body-desktop), regular);
     }
+
     text-align: center;
+    padding-top: ($grid * 1.4);
+    padding-bottom: $grid;
   }
 
   &__checkmark {

--- a/Checklist/styles.scss
+++ b/Checklist/styles.scss
@@ -9,6 +9,7 @@
 
   ul {
     list-style: none;
+    margin: 0;
     padding: ($grid * 2) ($grid * 4) ($grid * 2.8);
   }
 


### PR DESCRIPTION
Fix the margins and paddings of the `Checklist` so that they are the same as before the title and footer were introduced. Also only render `li`s inside the `ul` in order to render valid HTML.