### PR TITLE
Remove pointer cursor on disabled Switch

### DIFF
--- a/Switch/Checkbox/styles.scss
+++ b/Switch/Checkbox/styles.scss
@@ -42,6 +42,10 @@
     color: map-get($colors, error);
   }
 
+  .is-disabled & {
+    cursor: default;
+  }
+
   .legal & {
     @include typography(map-get($font-sizes, legal-mobile), regular);
 

--- a/Switch/Toggle/styles.scss
+++ b/Switch/Toggle/styles.scss
@@ -36,6 +36,10 @@
     color: map-get($colors, error);
   }
 
+  .is-disabled & {
+    cursor: default;
+  }
+
   .is-focused & {
     color: map-get($colors, klarna-blue);
   }


### PR DESCRIPTION
Fix #260

As per other components, hovering over a disabled Switch (Checkbox and Toggle) gives a default cursor.